### PR TITLE
Added the ability to configure the start command via a config file.

### DIFF
--- a/Commands/StartCommand.php
+++ b/Commands/StartCommand.php
@@ -19,11 +19,11 @@ class StartCommand extends Command
 
         $this
             ->setName('start')
-            ->addArgument('working-directory', null, 'The working directory. ', './')
-            ->addOption('bridge', null, InputOption::VALUE_REQUIRED, 'The bridge we use to convert a ReactPHP-Request to your target framework.')
-            ->addOption('port', null, InputOption::VALUE_OPTIONAL, 'Load-Balancer port. Default is 8080')
-            ->addOption('workers', null, InputOption::VALUE_OPTIONAL, 'Worker count. Default is 8. Should be minimum equal to the number of CPU cores.')
-            ->addOption('app-env', null, InputOption::VALUE_OPTIONAL)
+            ->addArgument('working-directory', InputOption::VALUE_OPTIONAL, 'The root of your appplication.', ['./'])
+            ->addOption('bridge', null, InputOption::VALUE_OPTIONAL, 'The bridge we use to convert a ReactPHP-Request to your target framework.', 'symfony')
+            ->addOption('port', null, InputOption::VALUE_OPTIONAL, 'Load-Balancer port. Default is 8080', 8080)
+            ->addOption('workers', null, InputOption::VALUE_OPTIONAL, 'Worker count. Default is 8. Should be minimum equal to the number of CPU cores.', 8)
+            ->addOption('app-env', null, InputOption::VALUE_OPTIONAL, 'The environment setting your app will be passed', 'prod')
             ->setDescription('Starts the server')
         ;
     }
@@ -34,15 +34,21 @@ class StartCommand extends Command
             chdir($workingDir);
         }
 
-        $bridge  = $input->getOption('bridge');
+        $config = [];
+        if (file_exists('./ppm.json')) {
+            $config = json_decode(file_get_contents('./ppm.json'), true);
+        }
 
-        $port    = null !== $input->getOption('port') ? (int) $input->getOption('port') : 8080;
-        $workers = null !== $input->getOption('workers') ? (int) $input->getOption('workers') : 8;
-        $appenv  = null !== $input->getOption('app-env') ? $input->getOption('app-env') : 'prod';
+        $bridge  = isset($config['bridge'])  ? $config['bridge']  : $input->getOption('bridge');
+        $port    = isset($config['port'])    ? $config['port']    : (int) $input->getOption('port');
+        $workers = isset($config['workers']) ? $config['workers'] : (int) $input->getOption('workers');
+        $appenv  = isset($config['app-env']) ? $config['app-env'] : $input->getOption('app-env');
 
         $handler = new ProcessManager($port, $workers);
+
         $handler->setBridge($bridge);
         $handler->setAppEnv($appenv);
+
         $handler->run();
     }
 


### PR DESCRIPTION
This allows you to place a ppm.json file within your project root and then simply issue `ppm start` to start the server.

ppm.json file:

```
{
    "bridge": "symfony",
    "port": 8888,
    "workers": 8,
    "app-env": "dev"
}
```

I'm not 100% convinced that json should be the format used. If you have any preferences let me know.
