### PR TITLE
Fixed typo

### DIFF
--- a/Commands/StartCommand.php
+++ b/Commands/StartCommand.php
@@ -44,7 +44,7 @@ class StartCommand extends Command
         $bridge        = $this->optionOrConfig($input, $config, 'bridge');
         $port          = (int) $this->optionOrConfig($input, $config, 'port');
         $workers       = (int) $this->optionOrConfig($input, $config, 'workers');
-        $appenv        = $this->optionOrConfig($input, $config, 'appenv');
+        $appenv        = $this->optionOrConfig($input, $config, 'app-env');
         $appBootstrap  = $this->optionOrConfig($input, $config, 'bootstrap');
 
         $handler = new ProcessManager($port, $workers);


### PR DESCRIPTION
Old ppm.json files might also contain this typo, therefore people who used this feature before should take care
