### PR TITLE
Fix dead child processes

### DIFF
--- a/ProcessManager.php
+++ b/ProcessManager.php
@@ -221,6 +221,7 @@ class ProcessManager
                         if ($slave['connection'] === $conn) {
                             unset($this->slaves[$idx]);
                             $this->checkSlaves();
+                            pcntl_waitpid($slave['pid'], $pidStatus);
                         }
                     }
                 },


### PR DESCRIPTION
If a child process dies, it stays in the process tree as a zombie.
As a solution I have added a `pcntl_waitpid` to get rid of a dead child.