### PR TITLE
Detect Composer Autoloader

### DIFF
--- a/ProcessManager.php
+++ b/ProcessManager.php
@@ -562,7 +562,9 @@ class ProcessManager
         $script = <<<EOF
 <?php
 
-include $dir . '/vendor/autoload.php';
+require_once file_exists($dir . '/vendor/autoload.php')
+    ? $dir . '/vendor/autoload.php'
+    : $dir . '/../../autoload.php';
 
 new \PHPPM\ProcessSlave('{$this->getBridge()}', '{$this->getAppBootstrap()}', [
     'app-env' => '{$this->getAppEnv()}',


### PR DESCRIPTION
Detect if Composer's autoload file can be find in the vendor directory in this project (if this project is the root package), otherwise assume that this project has been installed as a dependency and load the root package autoloader.
Also, change `include` to `require_once`; the autoloader is required (once only) to load the `ProcessSlave` class.