### PR TITLE
Add configuration option `php-cgi`.

### DIFF
--- a/Commands/ConfigTrait.php
+++ b/Commands/ConfigTrait.php
@@ -22,7 +22,8 @@ trait ConfigTrait
             ->addOption('debug', null, InputOption::VALUE_OPTIONAL, 'Activates debugging so that your application is more verbose, enables also hot-code reloading. 1|0', 1)
             ->addOption('logging', null, InputOption::VALUE_OPTIONAL, 'Deactivates the http logging to stdout. 1|0', 1)
             ->addOption('max-requests', null, InputOption::VALUE_OPTIONAL, 'Max requests per worker until it will be restarted', 1000)
-            ->addOption('bootstrap', null, InputOption::VALUE_OPTIONAL, 'The class that will be used to bootstrap your application', 'PHPPM\Bootstraps\Symfony');
+            ->addOption('bootstrap', null, InputOption::VALUE_OPTIONAL, 'The class that will be used to bootstrap your application', 'PHPPM\Bootstraps\Symfony')
+            ->addOption('php-cgi', null, InputOption::VALUE_OPTIONAL, 'Full path to the php-cgi executable', false);
     }
     
     protected function renderConfig(OutputInterface $output, array $config)
@@ -55,6 +56,7 @@ trait ConfigTrait
         $config['logging'] = $this->optionOrConfigValue($input, 'logging', $config);
         $config['bootstrap'] = $this->optionOrConfigValue($input, 'bootstrap', $config);
         $config['max-requests'] = (int)$this->optionOrConfigValue($input, 'max-requests', $config);
+        $config['php-cgi'] = $this->optionOrConfigValue($input, 'php-cgi', $config);
 
         return $config;
     }

--- a/Commands/StartCommand.php
+++ b/Commands/StartCommand.php
@@ -55,6 +55,7 @@ class StartCommand extends Command
         $handler->setLogging((boolean)$config['logging']);
         $handler->setAppBootstrap($config['bootstrap']);
         $handler->setMaxRequests($config['max-requests']);
+        $handler->setPhpCgiExecutable($config['php-cgi']);
 
         $handler->run();
     }

--- a/ProcessManager.php
+++ b/ProcessManager.php
@@ -110,6 +110,14 @@ class ProcessManager
      */
     protected $maxRequests = 1000;
 
+    /**
+     * Full path to the php-cgi executable. If not set, we try to determine the
+     * path automatically.
+     *
+     * @var string
+     */
+    protected $phpCgiExecutable = false;
+
     protected $filesToTrack = [];
     protected $filesLastMTime = [];
 
@@ -168,6 +176,14 @@ class ProcessManager
     public function setMaxRequests($maxRequests)
     {
         $this->maxRequests = $maxRequests;
+    }
+
+    /**
+     * @param string $phpCgiExecutable
+     */
+    public function setPhpCgiExecutable($phpCgiExecutable)
+    {
+        $this->phpCgiExecutable = $phpCgiExecutable;
     }
 
     /**
@@ -662,8 +678,12 @@ require_once file_exists($dir . '/vendor/autoload.php')
 new \PHPPM\ProcessSlave($bridge, $bootstrap, $config);
 EOF;
 
-        $executableFinder = new PhpExecutableFinder();
-        $commandline = $executableFinder->find() . '-cgi';
+        if ($this->phpCgiExecutable) {
+          $commandline = $this->phpCgiExecutable;
+        } else {
+          $executableFinder = new PhpExecutableFinder();
+          $commandline = $executableFinder->find() . '-cgi';
+        }
 
         $file = tempnam(sys_get_temp_dir(), 'dbg');
         file_put_contents($file, $script);

--- a/README.md
+++ b/README.md
@@ -41,9 +41,17 @@ To get PHP-PM you need beside the php binary also php-cgi, which comes often wit
 
 `apt-get install php7.0-cgi`
 
-**Mac OSX** (https://github.com/Homebrew/homebrew-php)
+**Mac OS X - Homebrew** (https://github.com/Homebrew/homebrew-php)
 
 `brew install php70`
+
+**Mac OS X - Macports**
+
+`port install php70-cgi`
+
+By default, PPM looks for a binary named `php-cgi`. If your PHP installation uses
+a different binary name, you can specify the full path to that binary with the `php-cgi`
+configuration option (for example: `ppm config --php-cgi=/opt/local/bin/php-cgi70`).
 
 #### Global
 


### PR DESCRIPTION
Depending on how PHP was compiled, the name of the `php-cgi` can differ from installation to installation. Macports uses `php-cgi70` for example. In that case, auto-guessing the binary name doesn't work.

Therefore, I've added the optional configuration option `php-cgi` so you can specify the full path to your php-cgi executable:

`ppm config --php-cgi=/opt/local/bin/php-cgi70`