### PR TITLE
process manager is trying to close not existent connection 

### DIFF
--- a/ProcessManager.php
+++ b/ProcessManager.php
@@ -723,7 +723,9 @@ class ProcessManager
 
             foreach ($this->slaves as &$slave) {
                 $slave['keepClosed'] = true;
-                $slave['connection']->close();
+                if(!empty($slave['connection'])) {
+                    $slave['connection']->close();
+                }
             }
         } else {
             $this->output->writeln(sprintf('<error>Application bootstrap failed. Restart worker ...</error>'));


### PR DESCRIPTION
I've integrated it with SF2.8 and cannot call close() on null appear.