### PR TITLE
Fix proxy/remote address problems with slaves

### DIFF
--- a/ProcessManager.php
+++ b/ProcessManager.php
@@ -459,7 +459,7 @@ class ProcessManager
 
                 $start = microtime(true);
 
-                $additionalHeader = ['X-Real-IP' => $incoming->getRemoteAddress()];
+                $additionalHeader = ['X-Remote-IP' => $incoming->getRemoteAddress()];
                 $headerRedirected = false;
 
                 if ($this->isHeaderEnd($buffer)) {

--- a/ProcessSlave.php
+++ b/ProcessSlave.php
@@ -389,9 +389,9 @@ class ProcessSlave
             $_SERVER['HTTP_' . strtoupper(str_replace('-', '_', $name))] = $value;
         }
 
-        //HTTP_X_REAL_IP is always set, either through ProcessMaster or by a proxy
-        //in front of ProcessMaster.
-        $_SERVER['REMOTE_ADDR'] = $_SERVER['HTTP_X_REAL_IP'];
+        //Using ProcessManager in front of the slaves masks the real/proxy ip
+        $_SERVER['REMOTE_ADDR'] = $_SERVER['HTTP_X_REMOTE_IP'];
+        unset($_SERVER['HTTP_X_REMOTE_IP']);
 
         $_SERVER['SERVER_NAME'] = isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : '';
         $_SERVER['REQUEST_URI'] = $request->getPath();


### PR DESCRIPTION
Fixes #97 

Hi Marc,

Your patch was populating the REMOTE_ADDRESS key with the real ip and hiding the fact that the PM was behind a proxy (nginx). What is expected in the REMOTE_ADDRESS is the origin address of the IP packet, either the real address (no proxy in front of PM) or the proxy address (nginx in front of PM). X-Real-IP will already be set by Nginx as per the normal reverse-proxy configs. We need a new temporary header for that.

Thanks!