### PR TITLE
Update Webtatic instructions to install only CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ By default cgi bin is in  `/usr/lib/cgi-bin/php`, so you need to run:
 
 **Red Hat/Centos (RHEL-7, 6)** (https://webtatic.com/packages/php70/)
 
-install webtatic first
+install Webtatic first
 
-`yum install php70w`
+`yum install php70w-cli`
 
 **Mac OS X - Homebrew** (https://github.com/Homebrew/homebrew-php)
 


### PR DESCRIPTION
The php70w package is the mod_php SAPI, which installs httpd.

It just happens for compatibility reasons, it depends on php70w-cli, so the cli and cgi SAPIs gets installed anyway.

The php70w-cli package includes both the cli and cgi SAPI binaries, /usr/bin/php and /usr/bin/php-cgi respectively