### PR TITLE
symfony/debug 2.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "require": {
         "symfony/console": "^2.6|^3.0",
         "symfony/process": "^2.6|^3.0",
-        "symfony/debug": "^2.6|^3.0",
+        "symfony/debug": "^2.8|^3.0",
         "react/event-loop": "^0.4",
         "react/stream": "^0.4",
         "react/http": "dev-master",


### PR DESCRIPTION
there is no class BufferingLogger in symfony/debug 2.6 which required by vendor/php-pm/php-pm/ProcessSlave.php:9