### PR TITLE
Define min php version in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "php-pm/php-pm",
     "require": {
+        "php": ">=5.6.0",
         "symfony/console": "^2.6|^3.0",
         "symfony/process": "^2.6|^3.0",
         "symfony/debug": "^2.8|^3.0",


### PR DESCRIPTION
Used 5.6 because its the oldest version which we use on travis

Per discussion in https://github.com/php-pm/php-pm/pull/123