### PR TITLE
clean up getMaxMemory function

### DIFF
--- a/Utils.php
+++ b/Utils.php
@@ -94,20 +94,22 @@ class Utils
     public static function getMaxMemory()
     {
         $memoryLimit = ini_get('memory_limit');
-        if (-1 === $memoryLimit) {
-            return 128 * 1024 * 1024; //default 128mb
+        
+        // if no limit
+        if (-1 == $memoryLimit) {
+            return 134217728; //128 * 1024 * 1024 default 128mb
         }
-
-        $lastChar = strtolower(substr($memoryLimit, -1));
-
-        if ('g' === $lastChar) {
-            $memoryLimit = substr($memoryLimit, 0, -1) * 1024 * 1024 * 1024;
-        } else if ('m' === $lastChar) {
-            $memoryLimit = substr($memoryLimit, 0, -1) * 1024 * 1024;
-        } else if ('k' === $lastChar) {
-            $memoryLimit = substr($memoryLimit, 0, -1) * 1024;
+        
+        // if set to exact byte
+        if (is_numeric($memoryLimit)) {
+            return (int) $memoryLimit;
         }
-
-        return $memoryLimit;
+        
+        // if short hand version http://php.net/manual/en/faq.using.php#faq.using.shorthandbytes
+        return substr($memoryLimit, 0, -1) * [
+            'g' => 1073741824, //1024 * 1024 * 1024
+            'm' => 1048576, //1024 * 1024
+            'k' => 1024
+        ][strtolower(substr($memoryLimit, -1))];
     }
 }


### PR DESCRIPTION
I had an issue with  -> if (-1 === $memoryLimit)

on ubuntu 16.04 with php 7.0.8 memory_limit on the CLI returned '-1' as a string so using == would be better than ===

also removed the multiplication [ micro optimization :) ] and cleaned up the if else statements.