### PR TITLE
Fix license info on Debug/BufferingLogger

### DIFF
--- a/Debug/BufferingLogger.php
+++ b/Debug/BufferingLogger.php
@@ -1,14 +1,37 @@
 <?php
 
+/*
+ * Based on Symfony's BufferingLogger
+ *
+ * Copyright (c) 2004-2016 Fabien Potencier
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 namespace PHPPM\Debug;
 
 use Psr\Log\AbstractLogger;
 
 /**
- * Class BufferingLogger
- *
  * A buffering logger that stacks logs for later.
- * Based on Symfony's BufferingLogger
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
  */
 class BufferingLogger extends AbstractLogger
 {


### PR DESCRIPTION
Sorry to raise this boring license issue, I'm sure it's an unfortunate mistake. Since this file comes from Symfony, it should be copyrighted to Fabien Potencier, as stated by Symfony's MIT license.
I'd also appreciate if you could keep the `@author` tag.
