### PR TITLE
Add sprintf placeholder

### DIFF
--- a/Commands/ConfigCommand.php
+++ b/Commands/ConfigCommand.php
@@ -32,7 +32,7 @@ class ConfigCommand extends Command
 
         $newContent = json_encode($config, JSON_PRETTY_PRINT);
         if (file_exists($this->file) && $newContent === file_get_contents($this->file)) {
-            $output->writeln(sprintf('No changes.', realpath($this->file)));
+            $output->writeln(sprintf('No changes to %s file.', realpath($this->file)));
             return;
         }
 


### PR DESCRIPTION
Another choice is to remove `sprintf` if log is too verbose like this.

```php 
$output->writeln('No changes');
```