### PR TITLE
Fix possible duplicates

### DIFF
--- a/React/RequestParser.php
+++ b/React/RequestParser.php
@@ -18,9 +18,10 @@ class RequestParser extends \React\Http\RequestParser
     protected function fixHeaderNames(Request $request)
     {
         $headers = $request->getHeaders();
-        foreach ($headers as $name => $v) {
+        foreach ($headers as $name => $value) {
             $newName = str_replace(' ', '-', ucwords(strtolower(str_replace('-', ' ', $name))));
-            $headers[$newName] = $headers[$name];
+            unset($headers[$name]);
+            $headers[$newName] = $value;
         }
 
         if (isset($headers['Content-Type'])) {


### PR DESCRIPTION
- In the case where a replacement would have occurred, the header would be doubled.
```php
Array
(
    [content-type] => text/html
    [Content-Type] => text/html
)
```