### PR TITLE
Update for React/Http - breaking change

### DIFF
--- a/React/RequestParser.php
+++ b/React/RequestParser.php
@@ -2,16 +2,15 @@
 
 namespace PHPPM\React;
 
-use React\Http\MultipartParser;
 use React\Http\Request;
 
-class RequestParser extends \React\Http\RequestParser
+class RequestParser extends \React\Http\RequestHeaderParser
 {
-    public function parseHeaders($data)
+    public function parseRequest($data)
     {
-        $request = parent::parseHeaders($data);
-        $this->fixHeaderNames($request);
-        return $request;
+        $return = parent::parseRequest($data);
+        $this->fixHeaderNames($return[0]);
+        return $return;
     }
 
     //fix header names (Content-type => Content-Type)
@@ -27,6 +26,6 @@ class RequestParser extends \React\Http\RequestParser
             $headers['Content-Type'] = explode(';', $headers['Content-Type'])[0];
         }
 
-        $request->__construct($request->getMethod(), $request->getUrl(), $request->getQuery(), $request->getHttpVersion(), $headers, $request->getBody());
+        $request->__construct($request->getMethod(), $request->getPath(), $request->getQuery(), $request->getHttpVersion(), $headers);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "symfony/process": "^2.6|^3.0",
         "react/event-loop": "^0.4",
         "react/stream": "^0.4",
-        "react/http": "dev-master#cd15204bd15d106d7832c680e4fb0ca0ce2f5e30",
+        "react/http": "^0.4",
         "react/socket-client": "^0.5.0",
         "mkraemer/react-pcntl": "2.0.*",
         "monolog/monolog": "^1.3"


### PR DESCRIPTION
Bridge should listen to data before running application. Simply add on-data listener with data argument instead of getBody which was removed from ReactRequest. Data are emitted

```php
public function onRequest(\React\Http\Request $react_request, HttpResponse $react_response) {
        $react_request->on('data', function($data) use ($react_request, $react_response) {
            ........
```