### PR TITLE
Added license section to the composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "php-pm/php-pm",
+    "license": "MIT",
     "require": {
         "php": ">=5.6.0",
         "symfony/console": "^2.6|^3.0",


### PR DESCRIPTION
There is no license information available for the latest version (`dev-master`) of this package.

Refs: https://getcomposer.org/doc/04-schema.md#license