### PR TITLE
Generate proper session IDs

### DIFF
--- a/Utils.php
+++ b/Utils.php
@@ -70,22 +70,7 @@ class Utils
      */
     public static function generateSessionId()
     {
-        $entropy = '';
-
-        $entropy .= uniqid(mt_rand(), true);
-        $entropy .= microtime(true);
-
-        if (function_exists('openssl_random_pseudo_bytes')) {
-            $entropy .= openssl_random_pseudo_bytes(32, $strong);
-        }
-        
-        if (function_exists('mcrypt_create_iv')) {
-            $entropy .= mcrypt_create_iv(32, MCRYPT_DEV_URANDOM);
-        }
-
-        $hash = hash('whirlpool', $entropy);
-
-        return $hash;
+        return \bin2hex(\random_bytes(32));
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         "react/http": "dev-master#cd15204bd15d106d7832c680e4fb0ca0ce2f5e30",
         "react/socket-client": "^0.5.0",
         "mkraemer/react-pcntl": "2.0.*",
-        "monolog/monolog": "^1.3"
+        "monolog/monolog": "^1.3",
+        "paragonie/random_compat": "^2"
     },
     "require-dev": {
         "php-pm/httpkernel-adapter": "dev-master",


### PR DESCRIPTION
Generates proper session IDs and fails closed if that's not possible. Before this patch the security of session IDs is highly dependent on the installed extensions and in the worst case falls back to a pure uniqid + microtime combination.

Thanks to @xhuberty for mentioning where he copied the broken code, so it can be fixed here, too.