### PR TITLE
Fail if --config option used and target file doesn't exist

### DIFF
--- a/Commands/ConfigCommand.php
+++ b/Commands/ConfigCommand.php
@@ -26,9 +26,11 @@ class ConfigCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $configPath = $this->getConfigPath($input, true);
+        if (!$configPath) {
+            $configPath = $this->file;
+        }
         $config = $this->loadConfig($input, $output);
-        // to be sure we have valid config path
-        $configPath = $this->getConfig($input);
 
         $this->renderConfig($output, $config);
 
@@ -40,18 +42,5 @@ class ConfigCommand extends Command
 
         file_put_contents($configPath, $newContent);
         $output->writeln(sprintf('<info>%s file written.</info>', realpath($configPath)));
-    }
-
-    /**
-     * @param InputInterface $input
-     * @return string
-     */
-    private function getConfig(InputInterface $input)
-    {
-        $configPath = $this->getConfigPath($input);
-        if (is_null($configPath)) {
-            $configPath = $input->getOption('config') ?: $this->file;
-        }
-        return $configPath;
     }
 }

--- a/Commands/ConfigTrait.php
+++ b/Commands/ConfigTrait.php
@@ -46,12 +46,22 @@ trait ConfigTrait
 
     /**
      * @param InputInterface $input
-     * @return null|string
+     * @param bool $create
+     * @return string
+     * @throws \Exception
      */
-    protected function getConfigPath(InputInterface $input)
+    protected function getConfigPath(InputInterface $input, $create = false)
     {
+        $configOption = $input->getOption('config');
+        if ($configOption && !file_exists($configOption)) {
+            if ($create) {
+                file_put_contents($configOption, json_encode([]));
+            } else {
+                throw new \Exception(sprintf('Config file not found: "%s"', $configOption));
+            }
+        }
         $possiblePaths = [
-            $input->getOption('config'),
+            $configOption,
             $this->file,
             sprintf('%s/%s', dirname($GLOBALS['argv'][0]), $this->file)
         ];
@@ -61,6 +71,7 @@ trait ConfigTrait
                 return realpath($path);
             }
         }
+        return '';
     }
 
     protected function loadConfig(InputInterface $input, OutputInterface $output)


### PR DESCRIPTION
Fails with all commands except Config (it creates file specified in --config option with default configuration).