### PR TITLE
Compatibility with react/socket 0.5, class React\Socket\ConnectionException has been removed

### DIFF
--- a/ProcessSlave.php
+++ b/ProcessSlave.php
@@ -3,6 +3,7 @@ declare(ticks = 1);
 
 namespace PHPPM;
 
+use RuntimeException;
 use PHPPM\React\HttpResponse;
 use PHPPM\React\HttpServer;
 use PHPPM\Debug\BufferingLogger;
@@ -310,7 +311,7 @@ class ProcessSlave
             try {
                 $this->server->listen($port, $host);
                 break;
-            } catch (\React\Socket\ConnectionException $e) {
+            } catch (RuntimeException $e) {
                 usleep(500);
             }
         }

--- a/ProcessSlave.php
+++ b/ProcessSlave.php
@@ -3,7 +3,6 @@ declare(ticks = 1);
 
 namespace PHPPM;
 
-use RuntimeException;
 use PHPPM\React\HttpResponse;
 use PHPPM\React\HttpServer;
 use PHPPM\Debug\BufferingLogger;
@@ -311,7 +310,7 @@ class ProcessSlave
             try {
                 $this->server->listen($port, $host);
                 break;
-            } catch (RuntimeException $e) {
+            } catch (\RuntimeException $e) {
                 usleep(500);
             }
         }

--- a/React/Server.php
+++ b/React/Server.php
@@ -5,7 +5,7 @@ namespace PHPPM\React;
 use Evenement\EventEmitter;
 use React\EventLoop\LoopInterface;
 use React\Socket\Connection;
-use React\Socket\ConnectionException;
+use RuntimeException;
 use React\Socket\ServerInterface;
 
 /**
@@ -46,7 +46,7 @@ class Server extends EventEmitter implements ServerInterface
         $this->master = stream_socket_server($localSocket, $errno, $errstr);
         if (false === $this->master) {
             $message = "Could not bind to $localSocket . Error: [$errno] $errstr";
-            throw new ConnectionException($message, $errno);
+            throw new RuntimeException($message, $errno);
         }
         stream_set_blocking($this->master, 0);
         $this->loop->addReadStream($this->master, function ($master) {

--- a/React/Server.php
+++ b/React/Server.php
@@ -5,7 +5,6 @@ namespace PHPPM\React;
 use Evenement\EventEmitter;
 use React\EventLoop\LoopInterface;
 use React\Socket\Connection;
-use RuntimeException;
 use React\Socket\ServerInterface;
 
 /**
@@ -46,7 +45,7 @@ class Server extends EventEmitter implements ServerInterface
         $this->master = stream_socket_server($localSocket, $errno, $errstr);
         if (false === $this->master) {
             $message = "Could not bind to $localSocket . Error: [$errno] $errstr";
-            throw new RuntimeException($message, $errno);
+            throw new \RuntimeException($message, $errno);
         }
         stream_set_blocking($this->master, 0);
         $this->loop->addReadStream($this->master, function ($master) {


### PR DESCRIPTION
There is a change in https://github.com/reactphp/socket/pull/72, which is not reflected in php-pm code.
The custom Recat\Socket\ConnectionException is removed and replaced by the generic \RuntimeException.