### PR TITLE
Added a protection against Unix socket connection problems

### DIFF
--- a/ProcessManager.php
+++ b/ProcessManager.php
@@ -479,7 +479,7 @@ class ProcessManager
             $slave['connections']++;
 
             $start = microtime(true);
-            $stream = stream_socket_client($slave['host'], $errno, $errstr, $this->timeout);
+            $stream = @stream_socket_client($slave['host'], $errno, $errstr, $this->timeout);
             if (!$stream || !is_resource($stream)) {
                 //we failed to connect to the worker. Maybe because of timeouts or it is in a crashed state
                 //and is currently dieing.

--- a/ProcessSlave.php
+++ b/ProcessSlave.php
@@ -270,13 +270,16 @@ class ProcessSlave
         $this->errorLogger = BufferingLogger::create();
         ErrorHandler::register(new ErrorHandler($this->errorLogger));
 
-        while (true) {
-            try {
-                $client = stream_socket_client($this->config['controllerHost']);
+        $client = false;
+        for ($attempts = 10; $attempts; --$attempts, usleep(mt_rand(500, 1000))) {
+            $client = @stream_socket_client($this->config['controllerHost'], $errno, $errstr);
+            if ($client) {
                 break;
-            } catch (\Exception $e) {
-                usleep(500);
             }
+        }
+        if (!$client) {
+            $message = "Could not bind to {$this->config['controllerHost']}. Error: [$errno] $errstr";
+            throw new \RuntimeException($message, $errno);
         }
         $this->controller = new \React\Socket\Connection($client, $this->loop);
 
@@ -306,15 +309,7 @@ class ProcessSlave
         $port = $this->config['port'];
         $host = $this->config['host'];
 
-        while (true) {
-            try {
-                $this->server->listen($port, $host);
-                break;
-            } catch (\RuntimeException $e) {
-                usleep(500);
-            }
-        }
-
+        $this->server->listen($port, $host);
         $this->sendMessage($this->controller, 'register', ['pid' => getmypid(), 'port' => $port]);
 
         $this->loop->run();

--- a/React/Server.php
+++ b/React/Server.php
@@ -42,7 +42,13 @@ class Server extends EventEmitter implements ServerInterface
                 'Supported transports are: IPv4, IPv6 and unix:// .'
                 , 1433253311);
         }
-        $this->master = stream_socket_server($localSocket, $errno, $errstr);
+
+        for ($attempts = 10; $attempts; --$attempts, usleep(mt_rand(500, 1000))) {
+            $this->master = @stream_socket_server($localSocket, $errno, $errstr);
+            if ($this->master) {
+                break;
+            }
+        }
         if (false === $this->master) {
             $message = "Could not bind to $localSocket . Error: [$errno] $errstr";
             throw new \RuntimeException($message, $errno);


### PR DESCRIPTION
This PR is a continuation of my comment in another PR: https://github.com/php-pm/php-pm/pull/223#issuecomment-291015404.

The problems with Unix socket connections appear very often when the system is under high load, especially when we meanwhile try to reload workers or restart the process manager. The simplest way to provoke the problem is using of great number of workers (>100). In this case it will be a problem with the access to the socket controller.sock (11: Resource temporarily unavailable). This is not the problem of php-pm or any used frameworks. This is the problem of a limited connection queue, which works with Unix sockets. We can try to tune the system by changing something like net.core.somaxconn, but anyway the code must be able to protect itself against possible errors.

In this PR there is a protection against E_WARNING errors in stream_socket_* functions.
When the connection error occurs, we wait form 0.5 to 1 second and try to repeat the connection up to 10 times. After 10 unsuccessful attempts in 5-10 seconds it is no reason to continue this process, exception is thrown and the process if closed - either a slave process or the master process. Slave processes will be then normally restarted by the ppm process manager. The master process should be restarted by the high-level process manager, like systemd or supervisord.

Warning: if we want to support Unix sockets for incoming web connections, we need to implement the same logic there.