### PR TITLE
Removed memory leak: growing watched files list in non-debug mode

### DIFF
--- a/ProcessSlave.php
+++ b/ProcessSlave.php
@@ -239,7 +239,9 @@ class ProcessSlave
      */
     public function registerFile($path)
     {
-        $this->watchedFiles[] = $path;
+        if ($this->isDebug()) {
+            $this->watchedFiles[] = $path;
+        }
     }
 
     /**
@@ -248,6 +250,10 @@ class ProcessSlave
      */
     protected function sendCurrentFiles()
     {
+        if (!$this->isDebug()) {
+            return;
+        }
+
         $files = array_merge($this->watchedFiles, get_included_files());
         $flipped = array_flip($files);
 
@@ -324,9 +330,7 @@ class ProcessSlave
     {
         $this->bootstrap($this->appBootstrap, $this->config['app-env'], $this->isDebug());
 
-        if ($this->isDebug()) {
-            $this->sendCurrentFiles();
-        }
+        $this->sendCurrentFiles();
     }
 
     /**
@@ -366,9 +370,7 @@ class ProcessSlave
 
             $bridge->onRequest($request, $response);
 
-            if ($this->isDebug()) {
-                $this->sendCurrentFiles();
-            }
+            $this->sendCurrentFiles();
         } else {
             $response->writeHead('404');
             $response->end('No Bridge Defined.');


### PR DESCRIPTION
In the Symfony adapter there is a code to collect Twig template file names to be checked by debug-mode watcher. These file names are collected after every request in any mode - both in debug and non-debug modes. But this problem is inside httpkernel-adapter and must be fixed separately.

In the slave process these file names are collected in the array. In the debug mode this array is sent to the master and is cleaned. But in non-debug mode this array is not sent and not cleaned, it only grows after every request.