### PR TITLE
Extract SlaveConnector class from ProcessManager

### DIFF
--- a/ProcessManager.php
+++ b/ProcessManager.php
@@ -1101,7 +1101,7 @@ EOF;
 
         $process = proc_open($commandline, $descriptorspec, $pipes);
 
-        $stderr = new ReadableResourceStream($pipes[2], $this->loop);
+        $stderr = new \React\Stream\Stream($pipes[2], $this->loop);
         $stderr->on(
             'data',
             function ($data) use ($port) {

--- a/ProcessManager.php
+++ b/ProcessManager.php
@@ -643,7 +643,7 @@ class ProcessManager
                 }
 
                 // we pick a slave that currently handles the fewest connections
-                if (null === $minConnections || $slave->getConnections() < $minConnections) {
+                if (null === $minConnections || $slave->getConnectionCount() < $minConnections) {
                     $minConnections = $slave->getConnections();
                     $minPort = $slave->getPort();
                 }

--- a/ProcessManager.php
+++ b/ProcessManager.php
@@ -1059,8 +1059,7 @@ class ProcessManager
             'app-env' => $this->getAppEnv(),
             'debug' => $this->isDebug(),
             'logging' => $this->isLogging(),
-            'static-directory' => $this->getStaticDirectory(),
-            'populate-server-var' => $this->isPopulateServer()
+            'static' => $this->isServingStatic()
         ];
 
         $config = var_export($config, true);

--- a/ProcessManager.php
+++ b/ProcessManager.php
@@ -1045,7 +1045,7 @@ class ProcessManager
 
         $host = Utils::isWindows() ? 'tcp://127.0.0.1' : $this->getNewSlaveSocket($port);
 
-        $slave = new SlaveProxy($host, $port, $bootstrapFailed);
+        $slave = new SlaveProcessConnection($host, $port, $bootstrapFailed);
 
         $bridge = var_export($this->getBridge(), true);
         $bootstrap = var_export($this->getAppBootstrap(), true);

--- a/ProcessManager.php
+++ b/ProcessManager.php
@@ -217,8 +217,8 @@ class ProcessManager
         $this->inShutdown = true;
 
         $this->output->writeln($graceful
-        	? '<info>Shutdown received, exiting.</info>'
-        	: '<error>Termination received, exiting.</error>'
+            ? '<info>Shutdown received, exiting.</info>'
+            : '<error>Termination received, exiting.</error>'
         );
 
         //this method is also called during startup when something crashed, so
@@ -235,14 +235,7 @@ class ProcessManager
         }
 
         foreach ($this->slaves as $slave) {
-            if (is_resource($slave['process'])) {
-                proc_terminate($slave['process']);
-            }
-
-            if ($slave['pid']) {
-                //make sure its dead
-                posix_kill($slave['pid'], SIGKILL);
-            }
+            $slave->terminate($graceful);
         }
         exit;
     }
@@ -469,25 +462,23 @@ class ProcessManager
 
             $took = microtime(true) - $start;
             if ($this->output->isVeryVerbose() && $took > 1) {
-                    $this->output->writeln(
-                        sprintf('<info>took abnormal %f seconds for choosing next free worker</info>', $took)
-                    );
+                $this->output->writeln(
+                    sprintf('<info>took abnormal %f seconds for choosing next free worker</info>', $took)
+                );
             }
 
             $slave =& $this->slaves[$id];
-            $slave['busy'] = true;
-            $slave['connections']++;
+            $slave->connect();
 
             $start = microtime(true);
-            $stream = @stream_socket_client($slave['host'], $errno, $errstr, $this->timeout);
+            $stream = stream_socket_client($slave->getHost(), $errno, $errstr, $this->timeout);
             if (!$stream || !is_resource($stream)) {
                 //we failed to connect to the worker. Maybe because of timeouts or it is in a crashed state
                 //and is currently dieing.
                 //since we don't know whether the worker is only very busy or dieing we just
                 //set it back to available worker list. If it is really dying it will be
                 //removed from the available worker list by itself during connection:close event.
-                $slave['busy'] = false;
-                $slave['connections']--;
+                $slave->disconnect();
 
                 if ($this->output->isVeryVerbose()) {
                     $this->output->writeln(
@@ -510,7 +501,7 @@ class ProcessManager
             $took = microtime(true) - $start;
             if ($this->output->isVeryVerbose() && $took > 1) {
                 $this->output->writeln(
-                    sprintf('<info>took abnormal %f seconds for connecting to :%d</info>', $took, $slave['port'])
+                    sprintf('<info>took abnormal %f seconds for connecting to :%d</info>', $took, $slave->getPort())
                 );
             }
 
@@ -530,7 +521,6 @@ class ProcessManager
             $connection->on(
                 'close',
                 function () use ($incoming, &$slave, $start) {
-
                     $took = microtime(true) - $start;
                     if ($this->output->isVeryVerbose() && $took > 1) {
                         $this->output->writeln(
@@ -538,21 +528,15 @@ class ProcessManager
                         );
                     }
 
-                    $slave['busy'] = false;
-                    $slave['connections']--;
-                    $slave['requests']++;
+                    $slave->disconnect(true);
                     $incoming->end();
-
-                    /** @var Connection $connection */
-                    $connection = $slave['connection'];
-
-                    if ($slave['requests'] >= $this->maxRequests) {
-                        $slave['ready'] = false;
-                        $this->output->writeln(sprintf('Restart worker #%d because it reached maxRequests of %d', $slave['port'], $this->maxRequests));
-                        $connection->close();
-                    } else if ($slave['closeWhenFree']) {
-                        $connection->close();
+//!!
+                    if ($slave->getRequestsHandled() >= $this->maxRequests) {
+                        $slave->setReady(false);
+                        $this->output->writeln(sprintf('Restart worker #%d because it reached maxRequests of %d', $slave->getPort(), $this->maxRequests));
                     }
+
+                    $slave->closeConnection();
                 }
             );
 
@@ -593,7 +577,6 @@ class ProcessManager
 
         $this->getNextSlave($redirectRequest);
     }
-
 
     /**
      * Checks whether the end of the header is in $buffer.
@@ -645,11 +628,11 @@ class ProcessManager
             $minPort = null;
 
             foreach ($this->slaves as $slave) {
-                if (!$slave['ready']) {
+                if (!$slave->getReady()) {
                     continue;
                 }
 
-                if (!$this->concurrentRequestsPerWorker && $slave['busy']) {
+                if (!$this->concurrentRequestsPerWorker && $slave->getBusy()) {
                     //we skip workers that are busy, means worker that are currently handle a connection
                     //this makes it more robust since most applications are not made to handle
                     //several request at the same time - even when one request is streaming. Would lead
@@ -660,9 +643,9 @@ class ProcessManager
                 }
 
                 // we pick a slave that currently handles the fewest connections
-                if (null === $minConnections || $slave['connections'] < $minConnections) {
-                    $minConnections = $slave['connections'];
-                    $minPort = $slave['port'];
+                if (null === $minConnections || $slave->getConnections() < $minConnections) {
+                    $minConnections = $slave->getConnections();
+                    $minPort = $slave->getPort();
                 }
             }
 
@@ -711,25 +694,16 @@ class ProcessManager
                     $slave =& $this->slaves[$port];
 
                     if ($this->output->isVeryVerbose()) {
-                        $this->output->writeln(sprintf('Worker #%d closed after %d handled requests', $slave['port'], $slave['requests']));
+                        $this->output->writeln(sprintf('Worker #%d closed after %d handled requests', $slave->getPort(), $slave->getRequests()));
                     }
 
-                    $slave['ready'] = false;
-                    if (isset($slave['stderr'])) {
-                        $slave['stderr']->close();
-                    }
+                    $slave->terminate(false);
 
-                    if (is_resource($slave['process'])) {
-                        proc_terminate($slave['process'], SIGKILL);
-                    }
-
-                    posix_kill($slave['pid'], SIGKILL); //make sure its really dead
-
-                    if ($slave['duringBootstrap']) {
+                    if ($slave->getDuringBootstrap()) {
                         $this->bootstrapFailed($conn);
                     }
 
-                    $this->newInstance($slave['port']);
+                    $this->newInstance($slave->getPort());
                 },
                 $this
             )
@@ -788,7 +762,7 @@ class ProcessManager
         $pid = (int)$data['pid'];
         $port = (int)$data['port'];
 
-        if (!isset($this->slaves[$port]) || !$this->slaves[$port]['waitForRegister']) {
+        if (!isset($this->slaves[$port]) || !$this->slaves[$port]->getWaitForRegister()) {
             if ($this->output->isVeryVerbose()) {
                 $this->output->writeln(sprintf(
                     '<error>Worker #%d wanted to register on master which was not expected.</error>',
@@ -804,11 +778,7 @@ class ProcessManager
             $this->output->writeln(sprintf('Worker #%d registered. Waiting for application bootstrap ... ', $port));
         }
 
-        $this->slaves[$port]['pid'] = $pid;
-        $this->slaves[$port]['connection'] = $conn;
-        $this->slaves[$port]['ready'] = false;
-        $this->slaves[$port]['waitForRegister'] = false;
-        $this->slaves[$port]['duringBootstrap'] = true;
+        $this->slaves[$port]->registerConnection($pid, $conn);
 
         $this->sendMessage($conn, 'bootstrap');
     }
@@ -849,16 +819,14 @@ class ProcessManager
     protected function commandReady(array $data, Connection $conn)
     {
         $port = $this->getPort($conn);
-        $this->slaves[$port]['ready'] = true;
-        $this->slaves[$port]['bootstrapFailed'] = 0;
-        $this->slaves[$port]['duringBootstrap'] = false;
+        $this->slaves[$port]->setReady();
 
         if ($this->output->isVeryVerbose()) {
             $this->output->writeln(sprintf('Worker #%d ready.', $port));
         }
 
-        $readySlaves = array_filter($this->slaves, function($item){
-            return $item['ready'];
+        $readySlaves = array_filter($this->slaves, function($slave){
+            return $slave->getReady();
         });
 
         if (($this->emergencyMode || $this->waitForSlaves) && $this->slaveCount === count($readySlaves)) {
@@ -890,10 +858,9 @@ class ProcessManager
     protected function bootstrapFailed(Connection $conn)
     {
         $port = $this->getPort($conn);
-        $this->slaves[$port]['bootstrapFailed']++;
+        $this->slaves[$port]->bootstrapFailed();
 
         if ($this->isDebug()) {
-
             $this->output->writeln('');
 
             if (!$this->emergencyMode) {
@@ -914,10 +881,7 @@ class ProcessManager
             }
 
             foreach ($this->slaves as &$slave) {
-                $slave['keepClosed'] = true;
-                if(!empty($slave['connection'])) {
-                    $slave['connection']->close();
-                }
+                $slave->seal();
             }
         } else {
             $this->output->writeln(sprintf('<error>Application bootstrap failed. Restart worker ...</error>'));
@@ -1035,25 +999,18 @@ class ProcessManager
         $this->output->writeln('Restart all worker');
 
         foreach ($this->slaves as &$slave) {
-            $slave['ready'] = false; //does not accept new connections
-            $slave['keepClosed'] = false;
+            //does not accept new connections
+            $slave->setReady(false);
 
             //important to not get 'bootstrap failed' exception, when the bootstrap changes files.
-            $slave['duringBootstrap'] = false;
-
-            $slave['bootstrapFailed'] = 0;
+            $slave->prepareForRestart();
 
             /** @var Connection $connection */
-            $connection = $slave['connection'];
-
+            $connection = $slave->getConnection();
             if ($connection && $connection->isWritable()) {
-                if ($slave['busy']) {
-                    $slave['closeWhenFree'] = true;
-                } else {
-                    $connection->close();
-                }
+                $slave->closeConnection();
             } else {
-                $this->newInstance($slave['port']);
+                $this->newInstance($slave->getPort());
             }
         };
 
@@ -1073,16 +1030,13 @@ class ProcessManager
             return;
         }
 
-        $keepClosed = false;
-        $bootstrapFailed = 0;
+        $bootstrapFailed = false;
 
         if (isset($this->slaves[$port])) {
-            $bootstrapFailed = $this->slaves[$port]['bootstrapFailed'];
-            $keepClosed = $this->slaves[$port]['keepClosed'];
-
-            if ($keepClosed) {
+            if ($this->slaves[$port]->getKeepClosed()) {
                 return;
             }
+            $bootstrapFailed = $this->slaves[$port]->getBootstrapFailed();
         }
 
         if ($this->output->isVeryVerbose()) {
@@ -1091,29 +1045,13 @@ class ProcessManager
 
         $host = Utils::isWindows() ? 'tcp://127.0.0.1' : $this->getNewSlaveSocket($port);
 
-        $slave = [
-            'ready' => false,
-            'pid' => null,
-            'port' => $port,
-            'closeWhenFree' => false,
-            'waitForRegister' => true,
-
-            'duringBootstrap' => false,
-            'bootstrapFailed' => $bootstrapFailed,
-            'keepClosed' => $keepClosed,
-
-            'busy' => false,
-            'requests' => 0,
-            'connections' => 0,
-            'connection' => null,
-            'host' => $host
-        ];
+        $slave = new SlaveProxy($host, $port, $bootstrapFailed);
 
         $bridge = var_export($this->getBridge(), true);
         $bootstrap = var_export($this->getAppBootstrap(), true);
         $config = [
-            'port' => $slave['port'],
-            'host' => $slave['host'],
+            'host' => $slave->getHost(),
+            'port' => $slave->getPort(),
 
             'session_path' => session_save_path(),
             'controllerHost' => Utils::isWindows() ? 'tcp://127.0.0.1' : $this->controllerHost,
@@ -1121,7 +1059,8 @@ class ProcessManager
             'app-env' => $this->getAppEnv(),
             'debug' => $this->isDebug(),
             'logging' => $this->isLogging(),
-            'static' => $this->isServingStatic(),
+            'static-directory' => $this->getStaticDirectory(),
+            'populate-server-var' => $this->isPopulateServer()
         ];
 
         $config = var_export($config, true);
@@ -1160,10 +1099,9 @@ EOF;
             ['pipe', 'w'], //stderr
         ];
 
-        $this->slaves[$port] = $slave;
-        $this->slaves[$port]['process'] = proc_open($commandline, $descriptorspec, $pipes);
+        $process = proc_open($commandline, $descriptorspec, $pipes);
 
-        $stderr = new \React\Stream\Stream($pipes[2], $this->loop);
+        $stderr = new ReadableResourceStream($pipes[2], $this->loop);
         $stderr->on(
             'data',
             function ($data) use ($port) {
@@ -1174,6 +1112,8 @@ EOF;
                 $this->output->write("<error>$data</error>");
             }
         );
-        $this->slaves[$port]['stderr'] = $stderr;
+        $slave->attach($process, $stderr);
+
+        $this->slaves[$port] = $slave;
     }
 }

--- a/ProcessManager.php
+++ b/ProcessManager.php
@@ -471,7 +471,7 @@ class ProcessManager
             $slave->connect();
 
             $start = microtime(true);
-            $stream = stream_socket_client($slave->getHost(), $errno, $errstr, $this->timeout);
+            $stream = @stream_socket_client($slave->getHost(), $errno, $errstr, $this->timeout);
             if (!$stream || !is_resource($stream)) {
                 //we failed to connect to the worker. Maybe because of timeouts or it is in a crashed state
                 //and is currently dieing.

--- a/ProcessManager.php
+++ b/ProcessManager.php
@@ -1030,7 +1030,7 @@ class ProcessManager
             return;
         }
 
-        $bootstrapFailed = false;
+        $bootstrapFailed = 0;
 
         if (isset($this->slaves[$port])) {
             if ($this->slaves[$port]->getKeepClosed()) {

--- a/ProcessManager.php
+++ b/ProcessManager.php
@@ -447,7 +447,7 @@ class ProcessManager
 
         $start = microtime(true);
         $redirectionTries++;
-        $redirectRequest = function ($id) use (&$redirectRequest, &$incoming, &$incomingBuffer, &$redirectionActive, $start, &$redirectionTries, &$connectionOpen) {
+        $redirectRequest = function ($port) use (&$redirectRequest, &$incoming, &$incomingBuffer, &$redirectionActive, $start, &$redirectionTries, &$connectionOpen) {
             if (!$connectionOpen) {
                 //since the initial connection of a client and getting a free worker the client meanwhile closed the connection,
                 //so stop anything here.
@@ -467,7 +467,7 @@ class ProcessManager
                 );
             }
 
-            $slave =& $this->slaves[$id];
+            $slave = $this->slaves[$port];
             $slave->connect();
 
             $start = microtime(true);
@@ -691,7 +691,7 @@ class ProcessManager
                     }
 
                     $port = $this->getPort($conn);
-                    $slave =& $this->slaves[$port];
+                    $slave = $this->slaves[$port];
 
                     if ($this->output->isVeryVerbose()) {
                         $this->output->writeln(sprintf('Worker #%d closed after %d handled requests', $slave->getPort(), $slave->getRequests()));
@@ -880,7 +880,7 @@ class ProcessManager
                 );
             }
 
-            foreach ($this->slaves as &$slave) {
+            foreach ($this->slaves as $slave) {
                 $slave->seal();
             }
         } else {
@@ -998,7 +998,7 @@ class ProcessManager
 
         $this->output->writeln('Restart all worker');
 
-        foreach ($this->slaves as &$slave) {
+        foreach ($this->slaves as $slave) {
             //does not accept new connections
             $slave->setReady(false);
 

--- a/ProcessManager.php
+++ b/ProcessManager.php
@@ -530,7 +530,7 @@ class ProcessManager
 
                     $slave->disconnect(true);
                     $incoming->end();
-//!!
+
                     if ($slave->getRequestsHandled() >= $this->maxRequests) {
                         $slave->setReady(false);
                         $this->output->writeln(sprintf('Restart worker #%d because it reached maxRequests of %d', $slave->getPort(), $this->maxRequests));

--- a/SlaveProcessConnection.php
+++ b/SlaveProcessConnection.php
@@ -136,7 +136,7 @@ class SlaveProcessConnection
         }
 
         if (is_resource($this->process)) {
-            proc_terminate($this->process, $graceful ? null : SIGKILL);
+            proc_terminate($this->process, $graceful ? SIGTERM : SIGKILL);
         }
 
         if ($this->pid) {

--- a/SlaveProcessConnection.php
+++ b/SlaveProcessConnection.php
@@ -5,7 +5,7 @@ namespace PHPPM;
 
 use React\Socket\Connection;
 
-class SlaveProxy
+class SlaveProcessConnection
 {
     /**
      * @var string

--- a/SlaveProcessConnection.php
+++ b/SlaveProcessConnection.php
@@ -108,14 +108,16 @@ class SlaveProcessConnection
 
     public function connect()
     {
-        $this->setBusy();
         $this->connections++;
+        $this->busy = true;
     }
 
     public function disconnect($handled = false)
     {
-        $this->setBusy(false);
         $this->connections--;
+        if ($this->connections === 0) {
+            $this->busy = false;
+        }
 
         if ($handled) {
             $this->requests++;
@@ -183,17 +185,9 @@ class SlaveProcessConnection
     }
 
     /**
-     * @param bool $busy
-     */
-    public function setBusy($busy = true)
-    {
-        $this->busy = $busy;
-    }
-
-    /**
      * @return int $connections
      */
-    public function getConnections()
+    public function getConnectionCount()
     {
         return $this->connections;
     }

--- a/SlaveProxy.php
+++ b/SlaveProxy.php
@@ -11,97 +11,97 @@ use Symfony\Component\Process\ProcessUtils;
 
 class SlaveProxy
 {
-	/**
-	 * @var string
-	 */
-	protected $host = null;
+    /**
+     * @var string
+     */
+    protected $host = null;
 
-	/**
-	 * @var int
-	 */
-	protected $port = null;
+    /**
+     * @var int
+     */
+    protected $port = null;
 
-	/**
-	 * @var bool
-	 */
-	protected $ready = false;
+    /**
+     * @var bool
+     */
+    protected $ready = false;
 
-	/**
-	 * @var bool
-	 */
-	protected $busy = false;
+    /**
+     * @var bool
+     */
+    protected $busy = false;
 
-	/**
-	 * @var bool
-	 */
-	protected $closeWhenFree = false;
+    /**
+     * @var bool
+     */
+    protected $closeWhenFree = false;
 
-	/**
-	 * @var bool
-	 */
-	protected $waitForRegister = true;
+    /**
+     * @var bool
+     */
+    protected $waitForRegister = true;
 
-	/**
-	 * @var bool
-	 */
-	protected $duringBootstrap = false;
+    /**
+     * @var bool
+     */
+    protected $duringBootstrap = false;
 
-	/**
-	 * @var bool
-	 */
-	protected $bootstrapFailed = 0;
+    /**
+     * @var bool
+     */
+    protected $bootstrapFailed = 0;
 
-	/**
-	 * @var bool
-	 */
-	protected $keepClosed = false;
+    /**
+     * @var bool
+     */
+    protected $keepClosed = false;
 
-	/**
-	 * @var int
-	 */
-	protected $requests = 0;
+    /**
+     * @var int
+     */
+    protected $requests = 0;
 
-	/**
-	 * @var int
-	 */
-	protected $connections = 0;
+    /**
+     * @var int
+     */
+    protected $connections = 0;
 
-	/**
-	 * @var int
-	 */
-	protected $pid = null;
+    /**
+     * @var int
+     */
+    protected $pid = null;
 
-	/**
-	 * @var resource
-	 */
-	protected $stderr = null;
+    /**
+     * @var resource
+     */
+    protected $stderr = null;
 
-	/**
-	 * @var ressource
-	 */
-	protected $connection = null;
+    /**
+     * @var ressource
+     */
+    protected $connection = null;
 
-	/**
-	 * SlaveProxy constructor
-	 *
-	 * @param string          $host
-	 * @param int             $port
-	 */
-	public function __construct($host, $port, $bootstrapFailed = 0)
-	{
-		$this->host = $host;
-		$this->port = $port;
-		$this->bootstrapFailed = $bootstrapFailed;
-	}
+    /**
+     * SlaveProxy constructor
+     *
+     * @param string          $host
+     * @param int             $port
+     */
+    public function __construct($host, $port, $bootstrapFailed = 0)
+    {
+        $this->host = $host;
+        $this->port = $port;
+        $this->bootstrapFailed = $bootstrapFailed;
+    }
 
-	/**
-	 * Slave connection established, update status
-	 *
-	 * @param int $pid slave process id
-	 * @param resource $conn slave connection
-	 */
-	public function registerConnection($pid, $conn)
-	{
+    /**
+     * Slave connection established, update status
+     *
+     * @param int $pid slave process id
+     * @param resource $conn slave connection
+     */
+    public function registerConnection($pid, $conn)
+    {
         $this->pid = $pid;
         $this->connection = $conn;
 
@@ -110,222 +110,222 @@ class SlaveProxy
         $this->duringBootstrap = true;
     }
 
-	public function connect()
-	{
-		$this->setBusy();
-		$this->connections++;
-	}
+    public function connect()
+    {
+        $this->setBusy();
+        $this->connections++;
+    }
 
-	public function disconnect($handled = false)
-	{
-		$this->setBusy(false);
-		$this->connections--;
+    public function disconnect($handled = false)
+    {
+        $this->setBusy(false);
+        $this->connections--;
 
-		if ($handled) {
-			$this->requests++;
-		}
-	}
+        if ($handled) {
+            $this->requests++;
+        }
+    }
 
-	/**
-	 * Handles termination signals, so we can gracefully stop all servers.
-	 */
-	public function terminate($graceful = false)
-	{
-		$this->read = false;
-		if (isset($this->stderr)) {
-			$this->stderr->close();
-			$this->stderr = null;
-		}
+    /**
+     * Handles termination signals, so we can gracefully stop all servers.
+     */
+    public function terminate($graceful = false)
+    {
+        $this->read = false;
+        if (isset($this->stderr)) {
+            $this->stderr->close();
+            $this->stderr = null;
+        }
 
-		if (is_resource($this->process)) {
-			proc_terminate($this->process, $graceful ? null : SIGKILL);
-		}
+        if (is_resource($this->process)) {
+            proc_terminate($this->process, $graceful ? null : SIGKILL);
+        }
 
-		if ($this->pid) {
-			//make sure its dead
-			posix_kill($this->pid, SIGKILL);
-		}
-	}
+        if ($this->pid) {
+            //make sure its dead
+            posix_kill($this->pid, SIGKILL);
+        }
+    }
 
-	/**
-	 * @return bool $ready
-	 */
-	public function getReady()
-	{
-		return $this->ready;
-	}
+    /**
+     * @return bool $ready
+     */
+    public function getReady()
+    {
+        return $this->ready;
+    }
 
-	/**
-	 * @param bool $ready
-	 */
-	public function setReady($ready = true)
-	{
-		$this->ready = $ready;
+    /**
+     * @param bool $ready
+     */
+    public function setReady($ready = true)
+    {
+        $this->ready = $ready;
 
         if ($ready) {
-	        $this->bootstrapFailed = 0;
-	        $this->duringBootstrap = false;
+            $this->bootstrapFailed = 0;
+            $this->duringBootstrap = false;
         }
-	}
+    }
 
-	/**
-	 * Mark slave for restart
-	 */
-	public function prepareForRestart()
-	{
-	    $this->keepClosed = false;
+    /**
+     * Mark slave for restart
+     */
+    public function prepareForRestart()
+    {
+        $this->keepClosed = false;
         $this->bootstrapFailed = 0;
         $this->duringBootstrap = false;
-	}
+    }
 
-	/**
-	 * @return bool $busy
-	 */
-	public function getBusy()
-	{
-		return $this->busy;
-	}
+    /**
+     * @return bool $busy
+     */
+    public function getBusy()
+    {
+        return $this->busy;
+    }
 
-	/**
-	 * @param bool $busy
-	 */
-	public function setBusy($busy = true)
-	{
-		$this->busy = $busy;
-	}
+    /**
+     * @param bool $busy
+     */
+    public function setBusy($busy = true)
+    {
+        $this->busy = $busy;
+    }
 
-	/**
-	 * @return int $connections
-	 */
-	public function getConnections()
-	{
-		return $this->connections;
-	}
+    /**
+     * @return int $connections
+     */
+    public function getConnections()
+    {
+        return $this->connections;
+    }
 
-	/**
-	 * @return string $connection
-	 */
-	public function getConnection()
-	{
-		return $this->connection;
-	}
+    /**
+     * @return string $connection
+     */
+    public function getConnection()
+    {
+        return $this->connection;
+    }
 
-	/**
-	 * Close slave connection or mark for closing
-	 *
-	 * @return bool connection was closed
-	 */
-	public function closeConnection()
-	{
-		if ($this->connection && $this->closeWhenFree) {
-			$this->connection->close();
-			$this->connection = null;
-		}
+    /**
+     * Close slave connection or mark for closing
+     *
+     * @return bool connection was closed
+     */
+    public function closeConnection()
+    {
+        if ($this->connection && $this->closeWhenFree) {
+            $this->connection->close();
+            $this->connection = null;
+        }
 
-		if ($this->connection && $this->connection->isWritable()) {
-			if ($this->busy) {
-				$this->closeWhenFree = true;
-			} else {
-				$this->connection->close();
-				$this->connection = null;
-			}
-		}
-	}
+        if ($this->connection && $this->connection->isWritable()) {
+            if ($this->busy) {
+                $this->closeWhenFree = true;
+            } else {
+                $this->connection->close();
+                $this->connection = null;
+            }
+        }
+    }
 
-	/**
-	 * Stop slave from accepting more connections
-	 */
-	public function seal()
-	{
-		$this->keepClosed = true;
+    /**
+     * Stop slave from accepting more connections
+     */
+    public function seal()
+    {
+        $this->keepClosed = true;
 
-		if ($this->connection) {
-			$this->connection->close();
-			$this->connection = null;
-		}
-	}
+        if ($this->connection) {
+            $this->connection->close();
+            $this->connection = null;
+        }
+    }
 
-	/**
-	 * Associate slave with process and stderr
-	 *
-	 * @param resource $process
-	 * @param resource $stderr
-	 */
-	public function attach($process, $stderr = null)
-	{
-		$this->process = $process;
-		$this->stderr = $stderr;
-	}
+    /**
+     * Associate slave with process and stderr
+     *
+     * @param resource $process
+     * @param resource $stderr
+     */
+    public function attach($process, $stderr = null)
+    {
+        $this->process = $process;
+        $this->stderr = $stderr;
+    }
 
-	/**
-	 * @return string $host
-	 */
-	public function getHost()
-	{
-		return $this->host;
-	}
+    /**
+     * @return string $host
+     */
+    public function getHost()
+    {
+        return $this->host;
+    }
 
-	/**
-	 * @return int $port
-	 */
-	public function getPort()
-	{
-		return $this->port;
-	}
+    /**
+     * @return int $port
+     */
+    public function getPort()
+    {
+        return $this->port;
+    }
 
-	/**
-	 * @return int $requests
-	 */
-	public function getRequestsHandled()
-	{
-		return $this->requests;
-	}
+    /**
+     * @return int $requests
+     */
+    public function getRequestsHandled()
+    {
+        return $this->requests;
+    }
 
-	/**
-	 * @return int
-	 */
-	public function getBootstrapFailed()
-	{
-		return $this->bootstrapFailed;
-	}
+    /**
+     * @return int
+     */
+    public function getBootstrapFailed()
+    {
+        return $this->bootstrapFailed;
+    }
 
-	/**
-	 * @return int
-	 */
-	public function bootstrapFailed()
-	{
-		return ++$this->bootstrapFailed;
-	}
+    /**
+     * @return int
+     */
+    public function bootstrapFailed()
+    {
+        return ++$this->bootstrapFailed;
+    }
 
-	/**
-	 * @return bool
-	 */
-	public function getDuringBootstrap()
-	{
-		return $this->duringBootstrap;
-	}
+    /**
+     * @return bool
+     */
+    public function getDuringBootstrap()
+    {
+        return $this->duringBootstrap;
+    }
 
-	/**
-	 * @param bool $duringBootstrap
-	 */
-	public function setDuringBootstrap($duringBootstrap)
-	{
-		return $this->duringBootstrap;
-	}
+    /**
+     * @param bool $duringBootstrap
+     */
+    public function setDuringBootstrap($duringBootstrap)
+    {
+        return $this->duringBootstrap;
+    }
 
-	/**
-	 * @return bool
-	 */
-	public function getKeepClosed()
-	{
-		return $this->keepClosed;
-	}
+    /**
+     * @return bool
+     */
+    public function getKeepClosed()
+    {
+        return $this->keepClosed;
+    }
 
-	/**
-	 * @return bool
-	 */
-	public function getWaitForRegister()
-	{
-		return $this->waitForRegister;
-	}
+    /**
+     * @return bool
+     */
+    public function getWaitForRegister()
+    {
+        return $this->waitForRegister;
+    }
 }

--- a/SlaveProxy.php
+++ b/SlaveProxy.php
@@ -4,10 +4,6 @@ declare(ticks = 1);
 namespace PHPPM;
 
 use React\Socket\Connection;
-use React\Stream\ReadableResourceStream;
-use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Debug\Debug;
-use Symfony\Component\Process\ProcessUtils;
 
 class SlaveProxy
 {
@@ -131,7 +127,7 @@ class SlaveProxy
      */
     public function terminate($graceful = false)
     {
-        $this->read = false;
+        $this->ready = false;
         if (isset($this->stderr)) {
             $this->stderr->close();
             $this->stderr = null;
@@ -301,14 +297,6 @@ class SlaveProxy
      * @return bool
      */
     public function getDuringBootstrap()
-    {
-        return $this->duringBootstrap;
-    }
-
-    /**
-     * @param bool $duringBootstrap
-     */
-    public function setDuringBootstrap($duringBootstrap)
     {
         return $this->duringBootstrap;
     }

--- a/SlaveProxy.php
+++ b/SlaveProxy.php
@@ -1,0 +1,331 @@
+<?php
+declare(ticks = 1);
+
+namespace PHPPM;
+
+use React\Socket\Connection;
+use React\Stream\ReadableResourceStream;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Debug\Debug;
+use Symfony\Component\Process\ProcessUtils;
+
+class SlaveProxy
+{
+	/**
+	 * @var string
+	 */
+	protected $host = null;
+
+	/**
+	 * @var int
+	 */
+	protected $port = null;
+
+	/**
+	 * @var bool
+	 */
+	protected $ready = false;
+
+	/**
+	 * @var bool
+	 */
+	protected $busy = false;
+
+	/**
+	 * @var bool
+	 */
+	protected $closeWhenFree = false;
+
+	/**
+	 * @var bool
+	 */
+	protected $waitForRegister = true;
+
+	/**
+	 * @var bool
+	 */
+	protected $duringBootstrap = false;
+
+	/**
+	 * @var bool
+	 */
+	protected $bootstrapFailed = 0;
+
+	/**
+	 * @var bool
+	 */
+	protected $keepClosed = false;
+
+	/**
+	 * @var int
+	 */
+	protected $requests = 0;
+
+	/**
+	 * @var int
+	 */
+	protected $connections = 0;
+
+	/**
+	 * @var int
+	 */
+	protected $pid = null;
+
+	/**
+	 * @var resource
+	 */
+	protected $stderr = null;
+
+	/**
+	 * @var ressource
+	 */
+	protected $connection = null;
+
+	/**
+	 * SlaveProxy constructor
+	 *
+	 * @param string          $host
+	 * @param int             $port
+	 */
+	public function __construct($host, $port, $bootstrapFailed = 0)
+	{
+		$this->host = $host;
+		$this->port = $port;
+		$this->bootstrapFailed = $bootstrapFailed;
+	}
+
+	/**
+	 * Slave connection established, update status
+	 *
+	 * @param int $pid slave process id
+	 * @param resource $conn slave connection
+	 */
+	public function registerConnection($pid, $conn)
+	{
+        $this->pid = $pid;
+        $this->connection = $conn;
+
+        $this->ready = false;
+        $this->waitForRegister = false;
+        $this->duringBootstrap = true;
+    }
+
+	public function connect()
+	{
+		$this->setBusy();
+		$this->connections++;
+	}
+
+	public function disconnect($handled = false)
+	{
+		$this->setBusy(false);
+		$this->connections--;
+
+		if ($handled) {
+			$this->requests++;
+		}
+	}
+
+	/**
+	 * Handles termination signals, so we can gracefully stop all servers.
+	 */
+	public function terminate($graceful = false)
+	{
+		$this->read = false;
+		if (isset($this->stderr)) {
+			$this->stderr->close();
+			$this->stderr = null;
+		}
+
+		if (is_resource($this->process)) {
+			proc_terminate($this->process, $graceful ? null : SIGKILL);
+		}
+
+		if ($this->pid) {
+			//make sure its dead
+			posix_kill($this->pid, SIGKILL);
+		}
+	}
+
+	/**
+	 * @return bool $ready
+	 */
+	public function getReady()
+	{
+		return $this->ready;
+	}
+
+	/**
+	 * @param bool $ready
+	 */
+	public function setReady($ready = true)
+	{
+		$this->ready = $ready;
+
+        if ($ready) {
+	        $this->bootstrapFailed = 0;
+	        $this->duringBootstrap = false;
+        }
+	}
+
+	/**
+	 * Mark slave for restart
+	 */
+	public function prepareForRestart()
+	{
+	    $this->keepClosed = false;
+        $this->bootstrapFailed = 0;
+        $this->duringBootstrap = false;
+	}
+
+	/**
+	 * @return bool $busy
+	 */
+	public function getBusy()
+	{
+		return $this->busy;
+	}
+
+	/**
+	 * @param bool $busy
+	 */
+	public function setBusy($busy = true)
+	{
+		$this->busy = $busy;
+	}
+
+	/**
+	 * @return int $connections
+	 */
+	public function getConnections()
+	{
+		return $this->connections;
+	}
+
+	/**
+	 * @return string $connection
+	 */
+	public function getConnection()
+	{
+		return $this->connection;
+	}
+
+	/**
+	 * Close slave connection or mark for closing
+	 *
+	 * @return bool connection was closed
+	 */
+	public function closeConnection()
+	{
+		if ($this->connection && $this->closeWhenFree) {
+			$this->connection->close();
+			$this->connection = null;
+		}
+
+		if ($this->connection && $this->connection->isWritable()) {
+			if ($this->busy) {
+				$this->closeWhenFree = true;
+			} else {
+				$this->connection->close();
+				$this->connection = null;
+			}
+		}
+	}
+
+	/**
+	 * Stop slave from accepting more connections
+	 */
+	public function seal()
+	{
+		$this->keepClosed = true;
+
+		if ($this->connection) {
+			$this->connection->close();
+			$this->connection = null;
+		}
+	}
+
+	/**
+	 * Associate slave with process and stderr
+	 *
+	 * @param resource $process
+	 * @param resource $stderr
+	 */
+	public function attach($process, $stderr = null)
+	{
+		$this->process = $process;
+		$this->stderr = $stderr;
+	}
+
+	/**
+	 * @return string $host
+	 */
+	public function getHost()
+	{
+		return $this->host;
+	}
+
+	/**
+	 * @return int $port
+	 */
+	public function getPort()
+	{
+		return $this->port;
+	}
+
+	/**
+	 * @return int $requests
+	 */
+	public function getRequestsHandled()
+	{
+		return $this->requests;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getBootstrapFailed()
+	{
+		return $this->bootstrapFailed;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function bootstrapFailed()
+	{
+		return ++$this->bootstrapFailed;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function getDuringBootstrap()
+	{
+		return $this->duringBootstrap;
+	}
+
+	/**
+	 * @param bool $duringBootstrap
+	 */
+	public function setDuringBootstrap($duringBootstrap)
+	{
+		return $this->duringBootstrap;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function getKeepClosed()
+	{
+		return $this->keepClosed;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function getWaitForRegister()
+	{
+		return $this->waitForRegister;
+	}
+}


### PR DESCRIPTION
Since the process manager is already hellishly complex I've tried to refactor the slave array members into their own class. Working after some quick testing but probably still contains errors.

Would appreciate review and testing.

**NOTE**

  - the graceful termination semantics seemed inconsistent- always use SIGKILL only when not graceful?
  - the busy bool seems inconsistent- only set busy false when no connections altogether?