### PR TITLE
fix: correct docblock for ports, ports an array of ints

### DIFF
--- a/ProcessManager.php
+++ b/ProcessManager.php
@@ -20,7 +20,7 @@ class ProcessManager
     /**
      * $object_hash => port
      *
-     * @var string[]
+     * @var int[]
      */
     protected $ports = [];
 


### PR DESCRIPTION
```php
    protected function commandRegister(array $data, Connection $conn)
    {
        $pid = (int)$data['pid'];
        $port = (int)$data['port']; # <--- cast to an integer

        if (!isset($this->slaves[$port]) || !$this->slaves[$port]['waitForRegister']) {
            if ($this->output->isVeryVerbose()) {
                $this->output->writeln(sprintf(
                    '<error>Worker #%d wanted to register on master which was not expected.</error>',
                    $port));
            }
            $conn->close();
            return;
        }

        $this->ports[spl_object_hash($conn)] = $port;
```

```php
    /**
     * @param Connection $conn
     *
     * @return null|int
     */
    protected function getPort(Connection $conn)
    {
        $id = spl_object_hash($conn);

        return $this->ports[$id];
    }
```

Port is cast to an `integer` before its assigned therefore we can be sure its a integer. The `getPort()` also only returns `int|null` so an array of ints keeps consistency with that.