### PR TITLE
fix: remove use of `$that` in the scope of the anonymous function

### DIFF
--- a/ProcessManager.php
+++ b/ProcessManager.php
@@ -639,8 +639,7 @@ class ProcessManager
      */
     protected function getNextSlave($cb)
     {
-        $that = $this;
-        $checkSlave = function () use ($cb, $that, &$checkSlave) {
+        $checkSlave = function () use ($cb, &$checkSlave) {
             $minConnections = null;
             $minPort = null;
 


### PR DESCRIPTION
I don't see `$that` being used in the anonymous function.