### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/Tests/PhpPmTestCase.php
+++ b/Tests/PhpPmTestCase.php
@@ -2,7 +2,9 @@
 
 namespace PHPPM\Tests;
 
-class PhpPmTestCase extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class PhpPmTestCase extends TestCase
 {
     protected function getProcessManagerMethod($method)
     {
@@ -13,4 +15,3 @@ class PhpPmTestCase extends \PHPUnit_Framework_TestCase
         }, $mock);
     }
 }
-

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require-dev": {
         "mockery/mockery": "^0.9.4",
-        "phpunit/phpunit": "^5.3"
+        "phpunit/phpunit": "^5.7"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "d4a05067b378aff056109308851083a0",
+    "content-hash": "b929aa860cc2470cb7303cbcc28207df",
     "packages": [
         {
             "name": "evenement/evenement",
@@ -533,7 +533,7 @@
                 "server",
                 "streaming"
             ],
-            "time": "2016-07-06 23:51:32"
+            "time": "2016-07-06T23:51:32+00:00"
         },
         {
             "name": "react/promise",


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^5.7`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-5.7.md#570---2016-12-02), that support this namespace.