### PR TITLE
Test as package and stand-alone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,12 @@ install:
   - composer install
 
 script:
+  # check with lock file  
+  - ./vendor/bin/phpunit
+
+  # check without lock file  
+  - rm composer.lock && rm -rf vendor
+  - composer install
   - ./vendor/bin/phpunit
 
 matrix:
@@ -21,7 +27,6 @@ matrix:
 # cache vendors
 cache:
   directories:
-    - vendor
     - $HOME/.composer/cache
 
 # This triggers builds to run on the new TravisCI infrastructure.


### PR DESCRIPTION
As long as the lock file is committed it makes sense to test if ppm is installable as library when lock file is not being utilised. 

Refs https://github.com/php-pm/php-pm/issues/272
