### PR TITLE
[wip] Fix edge cases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,9 @@ script:
   - bin/ppm stop
 
   # pid handling - must not overwrite before started
-  - bin/ppm start&
+  - bin/ppm start --bridge=StaticBridge&
   - sleep 5
-  - bin/ppm start || true
+  - bin/ppm start  --bridge=StaticBridge || true
   - bin/ppm stop
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
   # pid handling - must not overwrite before started
   - bin/ppm start --bridge=StaticBridge&
   - sleep 5
-  - bin/ppm start  --bridge=StaticBridge || true
+  - bin/ppm start --bridge=StaticBridge || true
   - bin/ppm stop
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,12 @@ script:
   - bin/ppm status
   - bin/ppm stop
 
+  # pid handling - must not overwrite before started
+  - bin/ppm start&
+  - sleep 5
+  - bin/ppm start || true
+  - bin/ppm stop
+
 matrix:
   fast_finish: true
 

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -65,7 +65,7 @@ class ProcessManager
     /**
      * @var array
      */
-    protected $slaves = [];
+    protected $slaves;
 
     /**
      * @var string
@@ -186,9 +186,12 @@ class ProcessManager
     public function __construct(OutputInterface $output, $port = 8080, $host = '127.0.0.1', $slaveCount = 8)
     {
         $this->output = $output;
-        $this->slaveCount = $slaveCount;
         $this->host = $host;
         $this->port = $port;
+
+        $this->slaveCount = $slaveCount;
+        $this->slaves = new SlavePool(); // create early, used during shutdown
+
         register_shutdown_function([$this, 'shutdown']);
     }
 
@@ -399,7 +402,6 @@ class ProcessManager
         $this->output->writeln("<info>Starting PHP-PM with {$this->slaveCount} workers, using {$loopClass} ...</info>");
         $this->writePid();
 
-        $this->slaves = new SlavePool();
         $this->createSlaves();
 
         $this->loop->run();

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -166,6 +166,11 @@ class ProcessManager
     protected $populateServer = true;
 
     /**
+     * PID if pidfile has been written
+     */
+    protected $pid;
+
+    /**
      * Location of the file where we're going to store the PID of the master process
      */
     protected $pidfile;
@@ -228,7 +233,9 @@ class ProcessManager
             $this->terminateSlave($slave);
         }
 
-        unlink($this->pidfile);
+        if ($this->pid) {
+            unlink($this->pidfile);
+        }
         exit;
     }
 
@@ -417,8 +424,8 @@ class ProcessManager
 
     public function writePid()
     {
-        $pid = getmypid();
-        file_put_contents($this->pidfile, $pid);
+        $this->__constructpid = getmypid();
+        file_put_contents($this->pidfile, $this->pid);
     }
 
     /**

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -424,7 +424,7 @@ class ProcessManager
 
     public function writePid()
     {
-        $this->__constructpid = getmypid();
+        $this->pid = getmypid();
         file_put_contents($this->pidfile, $this->pid);
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,3 +1,3 @@
 <?php
 
-require __DIR__ . ' /../vendor/autoload.php';
+require __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
  - test if pid overwritten before server started
  - setup slave pool early to avoid exception in shutdown

@marcj looking at

        $this->controllerHost = $this->getControllerSocketPath();

I'm wondering how we can gracefully check if another server is already running on this socket? May try connecting and error out if there's an answer?

There's also one other problem with `--debug 1` when file changes are detected as it shows an invalid "died during bootstrap" message.

Would be nice to complete these fixes before tagging 1.0.