### PR TITLE
Fix issues found by static analysis

### DIFF
--- a/src/Commands/ConfigCommand.php
+++ b/src/Commands/ConfigCommand.php
@@ -37,10 +37,12 @@ class ConfigCommand extends Command
         $newContent = json_encode($config, JSON_PRETTY_PRINT);
         if (file_exists($configPath) && $newContent === file_get_contents($configPath)) {
             $output->writeln(sprintf('No changes to %s file.', realpath($configPath)));
-            return;
+            return null;
         }
 
         file_put_contents($configPath, $newContent);
         $output->writeln(sprintf('<info>%s file written.</info>', realpath($configPath)));
+
+        return null;
     }
 }

--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -47,5 +47,7 @@ class StartCommand extends Command
         $handler->setPopulateServer($config['populate-server-var']);
         $handler->setStaticDirectory($config['static-directory']);
         $handler->run();
+
+        return null;
     }
 }

--- a/src/Commands/StatusCommand.php
+++ b/src/Commands/StatusCommand.php
@@ -38,6 +38,8 @@ class StatusCommand extends Command
         $handler->getStatus(function ($status) use ($output) {
             $output->writeln($this->parseStatus($status));
         });
+
+        return null;
     }
 
     /**

--- a/src/Commands/StopCommand.php
+++ b/src/Commands/StopCommand.php
@@ -40,5 +40,7 @@ class StopCommand extends Command
         $handler->stopProcessManager(function ($status) use ($output) {
             $output->writeln('Requested process manager to stop.');
         });
+
+        return null;
     }
 }

--- a/src/ProcessClient.php
+++ b/src/ProcessClient.php
@@ -23,8 +23,10 @@ class ProcessClient
 
     protected function request($command, $options, $callback)
     {
-        $data['cmd'] = $command;
-        $data['options'] = $options;
+        $data = [
+            'cmd' => $command,
+            'options' => $options
+        ];
 
         $connector = new UnixConnector($this->loop);
         $unixSocket = $this->getControllerSocketPath(false);

--- a/src/ProcessCommunicationTrait.php
+++ b/src/ProcessCommunicationTrait.php
@@ -20,7 +20,7 @@ trait ProcessCommunicationTrait
      * Parses a received message. Redirects to the appropriate `command*` method.
      *
      * @param ConnectionInterface $conn
-     * @param array $data
+     * @param string $data
      *
      * @throws \Exception when invalid 'cmd' in $data.
      */

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -63,9 +63,9 @@ class ProcessManager
     protected $maxRequests = 2000;
 
     /**
-     * @var array
+     * @var SlavePool
      */
-    protected $slaves = [];
+    protected $slaves;
 
     /**
      * @var string
@@ -305,7 +305,7 @@ class ProcessManager
     }
 
     /**
-     * @return string
+     * @return ?string
      */
     public function getAppEnv()
     {

--- a/src/ProcessSlave.php
+++ b/src/ProcessSlave.php
@@ -110,7 +110,7 @@ class ProcessSlave
      */
     protected $config;
 
-    public function __construct($socketpath, $bridgeName = null, $appBootstrap, array $config = [])
+    public function __construct($socketpath, $bridgeName, $appBootstrap, array $config = [])
     {
         $this->setSocketPath($socketpath);
 
@@ -246,7 +246,7 @@ class ProcessSlave
     protected function bootstrap($appBootstrap, $appenv, $debug)
     {
         if ($bridge = $this->getBridge()) {
-            $bridge->bootstrap($appBootstrap, $appenv, $debug, $this->loop);
+            $bridge->bootstrap($appBootstrap, $appenv, $debug);
             $this->sendMessage($this->controller, 'ready');
         }
     }

--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -53,6 +53,11 @@ class RequestHandler
     private $redirectionTries = 0;
     private $incomingBuffer = '';
 
+    /**
+     * @var ?float
+     */
+    private $start;
+
     public function __construct(LoopInterface $loop, OutputInterface $output, SlavePool $slaves)
     {
         $this->loop = $loop;
@@ -89,7 +94,7 @@ class RequestHandler
         $this->incomingBuffer .= $data;
 
         if ($this->connection && $this->isHeaderEnd($this->incomingBuffer)) {
-            $remoteAddress = $this->incoming->getRemoteAddress();
+            $remoteAddress = (string) $this->incoming->getRemoteAddress();
             $headersToReplace = [
                 'X-PHP-PM-Remote-IP' => trim(parse_url($remoteAddress, PHP_URL_HOST), '[]'),
                 'X-PHP-PM-Remote-Port' => trim(parse_url($remoteAddress, PHP_URL_PORT), '[]')
@@ -127,7 +132,7 @@ class RequestHandler
     /**
      * Slave available handler
      *
-     * @param array $slave available slave instance
+     * @param Slave $slave available slave instance
      */
     public function slaveAvailable(Slave $slave)
     {

--- a/src/Slave.php
+++ b/src/Slave.php
@@ -164,16 +164,6 @@ class Slave
     }
 
     /**
-     * Get slave socket path
-     *
-     * @return string slave socket path
-     */
-    public function getSocketPath()
-    {
-        return $this->socketPath;
-    }
-
-    /**
      * Get slave incoming connection
      *
      * @return ConnectionInterface slave connection

--- a/src/SlavePool.php
+++ b/src/SlavePool.php
@@ -9,6 +9,7 @@ use React\Socket\ConnectionInterface;
  */
 class SlavePool
 {
+    /** @var Slave[] */
     private $slaves = [];
 
     /**
@@ -54,7 +55,7 @@ class SlavePool
      * Get slave by port
      *
      * @param int $port
-     * @return void
+     * @return Slave
      */
     public function getByPort($port)
     {


### PR DESCRIPTION
All *incredibly* benign. Mostly just a bunch of errant docblocks.

I removed `Slave::getSocketPath()` because I don't think it's being used, and it references a non-existent property.

A few methods override `Symfony\Component\Console\Command\Command::execute`. It expects a return type of `int|null`, but as it's just a docblock so there are no actual complaints. Still, if it's ever properly typed then those explicit `return null` statements will come in handy.

Found with [Psalm](https://github.com/vimeo/psalm) and [this config](https://github.com/muglug/php-pm/blob/0ffe16a7f5d3c072b98897751d8373715c8f5be8/psalm.xml) which ignores a bunch of issues you probably don't care about.

