### PR TITLE
Add Psalm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ install:
 script:
   # Unit test
   - ./vendor/bin/phpunit
+  # Static Analysis
+  - ./vendor/bin/psalm --show-info=false
   # Integration test
   - mkdir web && echo "Hello" > web/index.html
   - bin/ppm start --workers=1 --bridge=StaticBridge --static-directory=web --max-requests=1 -v &

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^5.7",
+        "vimeo/psalm": "^0.3.76"
     },
     "autoload": {
         "psr-4": {

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<psalm
+    name="Example Psalm config with recommended defaults"
+    stopOnFirstError="false"
+    useDocblockTypes="true"
+    totallyTyped="false"
+>
+    <projectFiles>
+        <directory name="src" />
+    </projectFiles>
+
+    <issueHandlers>
+        <LessSpecificReturnType errorLevel="info" />
+
+        <!-- level 3 issues - slightly lazy code writing, but provably low false-negatives -->
+        <DeprecatedMethod errorLevel="info" />
+
+        <MissingClosureReturnType errorLevel="info" />
+        <MissingReturnType errorLevel="info" />
+        <MissingPropertyType errorLevel="info" />
+        <InvalidDocblock errorLevel="info" />
+
+        <PropertyNotSetInConstructor errorLevel="info" />
+        <MissingConstructor errorLevel="info" />
+        <UntypedParam errorLevel="info" />
+
+        <PossiblyFalseArgument errorLevel="info" />
+        <InvalidFalsableReturnType errorLevel="info" />
+
+        <InvalidOperand errorLevel="info" />
+        <PossiblyNullOperand errorLevel="info" />
+
+        <InvalidScalarArgument errorLevel="info" />
+    </issueHandlers>
+</psalm>

--- a/src/Bridges/BootstrapTrait.php
+++ b/src/Bridges/BootstrapTrait.php
@@ -32,7 +32,7 @@ trait BootstrapTrait
      */
     private function normalizeBootstrapClass($appBootstrap)
     {
-        $appBootstrap = str_replace('\\\\', '\\', $appBootstrap);
+        $appBootstrap = str_replace('\\\\', '\\', (string) $appBootstrap);
 
         $bootstraps = [
             $appBootstrap,

--- a/src/Commands/ConfigTrait.php
+++ b/src/Commands/ConfigTrait.php
@@ -111,6 +111,7 @@ trait ConfigTrait
             ];
 
             foreach ($cgiPaths as $cgiPath) {
+                /** @psalm-suppress ForbiddenCode */
                 $path = trim(`which $cgiPath`);
                 if ($path) {
                     $config['cgi-path'] = $path;

--- a/src/ProcessSlave.php
+++ b/src/ProcessSlave.php
@@ -293,7 +293,9 @@ class ProcessSlave
     {
         $this->loop = Factory::create();
 
+        /** @psalm-suppress InvalidPropertyAssignment */
         $this->errorLogger = BufferingLogger::create();
+        /** @psalm-suppress PossiblyInvalidArgument */
         ErrorHandler::register(new ErrorHandler($this->errorLogger));
 
         $connector = new UnixConnector($this->loop);

--- a/src/ProcessSlave.php
+++ b/src/ProcessSlave.php
@@ -365,6 +365,7 @@ class ProcessSlave
             return new Response(500);
         };
 
+        /** @psalm-suppress UndefinedClass for PHP 5.6-compatibility */
         try {
             $response = $this->handleRequest($request);
         } catch (\Throwable $t) {


### PR DESCRIPTION
This PR adds Psalm to the `require-dev`, and suppresses an issue with a possibly invalid argument in `src/ProcessSlave.php`.

Running `./vendor/bin/psalm` will show you its warnings, to get rid of them (like the build gets rid of them) you can run `./vendor/bin/psalm --show-info=false`. About 200 issues are ignored right now.

You can also configure what is a warning and what is a proper error in `psalm.xml`. If you want total type-safety, change `totallyTyped="false"` to `totallyTyped="true"`, and you'll see another 200 or so issues pop up for times where Psalm cannot infer the types of particular variables.

But this config will prevent new errors from being introduced, and so is a worthy first (or only) step.