### PR TITLE
Avoiding multiple restart of slave processes

### DIFF
--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -129,6 +129,11 @@ class ProcessManager
     protected $port = 8080;
 
     /**
+     * @var bool
+     */
+    protected $inChangesDetectionCycle = false;
+
+    /**
      * Whether the server is in the restart phase.
      *
      * @var bool
@@ -169,7 +174,6 @@ class ProcessManager
      */
     protected $lastWorkerErrorPrintBy;
 
-    protected $filesToTrack = [];
     protected $filesLastMTime = [];
     protected $filesLastMd5 = [];
 
@@ -755,10 +759,30 @@ class ProcessManager
         try {
             $slave = $this->slaves->getByConnection($conn);
 
-            if ($this->output->isVeryVerbose()) {
-                $this->output->writeln(sprintf('Received %d files from %d', count($data['files']), $slave->getPort()));
+            $start = microtime(true);
+
+            clearstatcache();
+
+            $newFilesCount = 0;
+            foreach (array_diff($data['files'], array_keys($this->filesLastMTime)) as $filePath) {
+                if (file_exists($filePath)) {
+                    $this->filesLastMTime[$filePath] = filemtime($filePath);
+                    $this->filesLastMd5[$filePath] = md5_file($filePath, true);
+                    $newFilesCount++;
+                }
             }
-            $this->filesToTrack = array_unique(array_merge($this->filesToTrack, $data['files']));
+
+            if ($this->output->isVeryVerbose()) {
+                $this->output->writeln(
+                    sprintf(
+                        'Received %d new files from %d. Stats collection cycle: %u files, %.3f ms',
+                        $newFilesCount,
+                        $slave->getPort(),
+                        count($this->filesLastMTime),
+                        (microtime(true) - $start) * 1000
+                    )
+                );
+            }
         } catch (\Exception $e) {
             // silent
         }
@@ -818,59 +842,54 @@ class ProcessManager
      */
     protected function checkChangedFiles($restartSlaves = true)
     {
-        if ($this->inRestart) {
+        if ($this->inChangesDetectionCycle) {
             return false;
         }
 
+        $start = microtime(true);
+        $hasChanged = false;
+
+        $this->inChangesDetectionCycle = true;
+
         clearstatcache();
 
-        $reload = false;
-        $filePath = '';
-        $start = microtime(true);
-
-        foreach ($this->filesToTrack as $idx => $filePath) {
+        foreach ($this->filesLastMTime as $filePath => $knownMTime) {
             if (!file_exists($filePath)) {
                 continue;
             }
 
-            $currentFileMTime = filemtime($filePath);
-
-            if (isset($this->filesLastMTime[$filePath])) {
-                if ($this->filesLastMTime[$filePath] !== $currentFileMTime) {
-                    $this->filesLastMTime[$filePath] = $currentFileMTime;
-
-                    $md5 = md5_file($filePath);
-                    if (!isset($this->filesLastMd5[$filePath]) || $md5 !== $this->filesLastMd5[$filePath]) {
-                        $this->filesLastMd5[$filePath] = $md5;
-                        $reload = true;
-
-                        //since chances are high that this file will change again we
-                        //move this file to the beginning of the array, so next check is way faster.
-                        unset($this->filesToTrack[$idx]);
-                        array_unshift($this->filesToTrack, $filePath);
-                        break;
-                    }
-                }
-            } else {
-                $this->filesLastMTime[$filePath] = $currentFileMTime;
+            if ($knownMTime !== filemtime($filePath) && $this->filesLastMd5[$filePath] !== md5_file($filePath, true)) {
+                $this->output->writeln(
+                    sprintf("<info>[%s] File %s has changed.</info>", date('d/M/Y:H:i:s O'), $filePath)
+                );
+                $hasChanged = true;
+                break;
             }
         }
 
-        if ($reload && $restartSlaves) {
+        if ($hasChanged) {
             $this->output->writeln(
                 sprintf(
-                    "<info>[%s] File changed %s (detection %.3f, %d). Reloading workers.</info>",
+                    "<info>[%s] At least one of %u known files was changed.</info>",
                     date('d/M/Y:H:i:s O'),
-                    $filePath,
-                    microtime(true) - $start,
-                    count($this->filesToTrack)
+                    count($this->filesLastMTime)
                 )
             );
 
-            $this->restartSlaves();
+            if ($this->output->isVeryVerbose()) {
+                $this->output->writeln(
+                    sprintf("Changes detection cycle length = %.3f ms", (microtime(true) - $start) * 1000)
+                );
+            }
+
+            if ($restartSlaves) {
+                $this->restartSlaves();
+            }
         }
 
-        return $reload;
+        $this->inChangesDetectionCycle = false;
+
+        return $hasChanged;
     }
 
     /**
@@ -995,6 +1014,9 @@ class ProcessManager
             }
         }
 
+        $this->filesLastMTime = [];
+        $this->filesLastMd5 = [];
+
         if ($this->reloadTimeoutTimer !== null) {
             $this->reloadTimeoutTimer->cancel();
         }
@@ -1028,12 +1050,13 @@ class ProcessManager
         }
 
         $this->inRestart = true;
-        $this->output->writeln('Restarting all workers');
+        $start = microtime(true);
 
         $this->closeSlaves();
         $this->createSlaves();
 
         $this->inRestart = false;
+        $this->output->writeln(sprintf("Workers have been restarted in %.3f ms.", (microtime(true) - $start) * 1000));
     }
 
     /**

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -764,7 +764,9 @@ class ProcessManager
             clearstatcache();
 
             $newFilesCount = 0;
-            foreach (array_diff($data['files'], array_keys($this->filesLastMTime)) as $filePath) {
+            $knownFiles = array_keys($this->filesLastMTime);
+            $recentlyIncludedFiles = array_diff($data['files'], $knownFiles);
+            foreach ($recentlyIncludedFiles as $filePath) {
                 if (file_exists($filePath)) {
                     $this->filesLastMTime[$filePath] = filemtime($filePath);
                     $this->filesLastMd5[$filePath] = md5_file($filePath, true);
@@ -1050,13 +1052,11 @@ class ProcessManager
         }
 
         $this->inRestart = true;
-        $start = microtime(true);
 
         $this->closeSlaves();
         $this->createSlaves();
 
         $this->inRestart = false;
-        $this->output->writeln(sprintf("Workers have been restarted in %.3f ms.", (microtime(true) - $start) * 1000));
     }
 
     /**

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -872,7 +872,7 @@ class ProcessManager
         if ($hasChanged) {
             $this->output->writeln(
                 sprintf(
-                    "<info>[%s] At least one of %u known files was changed.</info>",
+                    "<info>[%s] At least one of %u known files was changed. Reloading workers.</info>",
                     date('d/M/Y:H:i:s O'),
                     count($this->filesLastMTime)
                 )


### PR DESCRIPTION
In the Debug mode [`ProcessManager::checkChangedFiles()`](https://github.com/AntonTyutin/php-pm/blob/1.0.1/src/ProcessManager.php#L725) restarts slaves immediately when first modified file has found. If more then one watched files were changed, restarting process repeats so many times, how many files have changed.

I think we should detect all the changes and restart slaves only once per one detection cycle.