### PR TITLE
Allow nginx to set REMOTE_ADDR

### DIFF
--- a/src/ProcessSlave.php
+++ b/src/ProcessSlave.php
@@ -437,9 +437,11 @@ class ProcessSlave
 
         //We receive X-PHP-PM-Remote-IP and X-PHP-PM-Remote-Port from ProcessManager.
         //This headers is only used to proxy the remoteAddress and remotePort from master -> slave.
-        $_SERVER['REMOTE_ADDR'] = $_SERVER['HTTP_X_PHP_PM_REMOTE_IP'];
+        $_SERVER['REMOTE_ADDR'] = isset($_SERVER['HTTP_REMOTE_ADDR']) ? $_SERVER['HTTP_REMOTE_ADDR'] : $_SERVER['HTTP_X_PHP_PM_REMOTE_IP'];
+        unset($_SERVER['HTTP_REMOTE_ADDR']);
         unset($_SERVER['HTTP_X_PHP_PM_REMOTE_IP']);
-        $_SERVER['REMOTE_PORT'] = $_SERVER['HTTP_X_PHP_PM_REMOTE_PORT'];
+        $_SERVER['REMOTE_PORT'] = isset($_SERVER['HTTP_REMOTE_PORT']) ? $_SERVER['HTTP_REMOTE_PORT'] : $_SERVER['HTTP_X_PHP_PM_REMOTE_PORT'];
+        unset($_SERVER['HTTP_REMOTE_PORT']);
         unset($_SERVER['HTTP_X_PHP_PM_REMOTE_PORT']);
 
         $_SERVER['SERVER_NAME'] = isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : '';


### PR DESCRIPTION
As it stands, when proxying with nginx, `REMOTE_ADDR` will always be `127.0.0.1`. While it is possible to set and use `X_REAL_IP` or the like, existing software that depends on `REMOTE_ADDR` will have problems.

The solution proposed was inspired by php-fpm handling, where `REMOTE_ADDR` and `REMOTE_PORT` are set. However in an nginx proxy environment `HTTP_` is prepended to the `$_SERVER` variable.