### PR TITLE
fix ProcessUtils::escapeArgument() for Symfony 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,9 +5,9 @@
     "require": {
         "php": ">=5.6.0",
         "ext-pcntl":"*",
-        "symfony/console": "^2.6|^3.0",
-        "symfony/debug": "^2.6|^3.0",
-        "symfony/process": "^2.6|^3.0",
+        "symfony/console": "^2.6|^3.0|^4.0",
+        "symfony/debug": "^2.6|^3.0|^4.0",
+        "symfony/process": "^2.6|^3.0|^4.0",
         "react/event-loop": "^0.4",
         "react/stream": "^0.7.1",
         "react/http": "^0.8",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "php-pm/php-pm",
+    "name": "andreybolonin/php-pm",
     "description": "PHP-PM is a process manager, supercharger and load balancer for PHP applications.",
     "license": "MIT",
     "require": {

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -999,8 +999,8 @@ EOF;
     /**
      * Moved from vendor/symfony/process/ProcessUtils.php.
      *
-     * @param $arg
-     * @param $char
+     * @param string $arg
+     * @param string $char
      * @return bool
      */
     private static function isSurroundedBy($arg, $char)


### PR DESCRIPTION
`The Symfony\Component\Process\ProcessUtils::escapeArgument() method is deprecated since version 3.3 and will be removed in 4.0.`
https://github.com/symfony/symfony/blob/master/UPGRADE-4.0.md#process
ping @marcj