### PR TITLE
Added compatibility with symfony 4

### DIFF
--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -1,3 +1,4 @@
 parameters:
     ignoreErrors:
         - '#Result of method React\\Socket\\ServerInterface::close\(\) \(void\) is used#'
+        - '#Call to an undefined static method Symfony\\Component\\Process\\ProcessUtils::escapeArgument\(\)#'

--- a/composer.json
+++ b/composer.json
@@ -5,9 +5,9 @@
     "require": {
         "php": ">=5.6.0",
         "ext-pcntl":"*",
-        "symfony/console": "^2.6|^3.0",
-        "symfony/debug": "^2.6|^3.0",
-        "symfony/process": "^2.6|^3.0",
+        "symfony/console": "^2.6|^3.0|^4.0",
+        "symfony/debug": "^2.6|^3.0|^4.0",
+        "symfony/process": "^2.6|^3.0|^4.0",
         "react/event-loop": "^0.4",
         "react/stream": "^0.7.1",
         "react/http": "^0.8",

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -902,14 +902,18 @@ EOF;
         // we can not use -q since this disables basically all header support
         // but since this is necessary at least in Symfony we can not use it.
         // e.g. headers_sent() returns always true, although wrong.
-        if(method_exists('ProcessUtils', 'escapeArgument' )){
-            $commandline = $this->phpCgiExecutable . ' -C ' . ProcessUtils::escapeArgument($file);
-        }else{
-            $commandline = [$this->phpCgiExecutable, '-C', $file];
+        //For version 2.x and 3.x of \Symfony\Component\Process\Process package
+        if (method_exists('\Symfony\Component\Process\ProcessUtils', 'escapeArgument')) {
+            $commandline = 'exec ' . $this->phpCgiExecutable . ' -C ' . ProcessUtils::escapeArgument($file);
+        } else {
+            //For version 4.x of \Symfony\Component\Process\Process package
+            $commandline = ['exec', $this->phpCgiExecutable, '-C', $file];
+            $processInstance = new \Symfony\Component\Process\Process($commandline);
+            $commandline = $processInstance->getCommandLine();
         }
 
         // use exec to omit wrapping shell
-        $process = new Process('exec ' . $commandline);
+        $process = new Process($commandline);
 
         $slave = new Slave($port, $this->maxRequests);
         $slave->attach($process);

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -902,7 +902,11 @@ EOF;
         // we can not use -q since this disables basically all header support
         // but since this is necessary at least in Symfony we can not use it.
         // e.g. headers_sent() returns always true, although wrong.
-        $commandline = $this->phpCgiExecutable . ' -C ' . ProcessUtils::escapeArgument($file);
+        if(method_exists('ProcessUtils', 'escapeArgument' )){
+            $commandline = $this->phpCgiExecutable . ' -C ' . ProcessUtils::escapeArgument($file);
+        }else{
+            $commandline = [$this->phpCgiExecutable, '-C', $file];
+        }
 
         // use exec to omit wrapping shell
         $process = new Process('exec ' . $commandline);


### PR DESCRIPTION
The Symfony\Component\Process\ProcessUtils::escapeArgument() method is deprecated since version 3.3 and will be removed in 4.0.

https://github.com/symfony/symfony/blob/master/UPGRADE-4.0.md#process

but the \Symfony\Component\Process\Process class has a private escapeArgument functions that you can used by calling the getCommandLine after a creation of the object.

ping @marcj