### PR TITLE
Adding the `QUERY_STRING` to the `$_SERVER['REQUEST_URI']`

### DIFF
--- a/src/ProcessSlave.php
+++ b/src/ProcessSlave.php
@@ -443,7 +443,7 @@ class ProcessSlave
         unset($_SERVER['HTTP_X_PHP_PM_REMOTE_PORT']);
 
         $_SERVER['SERVER_NAME'] = isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : '';
-        $_SERVER['REQUEST_URI'] = $request->getUri()->getPath();
+        $_SERVER['REQUEST_URI'] = $request->getUri()->getPath() . ($_SERVER['QUERY_STRING'] ? '?' . $_SERVER['QUERY_STRING'] : '');
         $_SERVER['DOCUMENT_ROOT'] = isset($_ENV['DOCUMENT_ROOT']) ? $_ENV['DOCUMENT_ROOT'] : getcwd();
         $_SERVER['SCRIPT_NAME'] = isset($_ENV['SCRIPT_NAME']) ? $_ENV['SCRIPT_NAME'] : 'index.php';
         $_SERVER['SCRIPT_FILENAME'] = rtrim($_SERVER['DOCUMENT_ROOT'], '/') . '/' . $_SERVER['SCRIPT_NAME'];


### PR DESCRIPTION
Major web-servers populate `REQUEST_URI` parameter by _path_ and _query_ parts of the URL.