### PR TITLE
Implement reload command, graceful shutdowns

### DIFF
--- a/bin/ppm
+++ b/bin/ppm
@@ -25,12 +25,14 @@ if (!PHPPM\pcntl_enabled()) {
 use Symfony\Component\Console\Application;
 use PHPPM\Commands\StartCommand;
 use PHPPM\Commands\StopCommand;
+use PHPPM\Commands\ReloadCommand;
 use PHPPM\Commands\StatusCommand;
 use PHPPM\Commands\ConfigCommand;
 
 $app = new Application('PHP-PM');
 $app->add(new StartCommand);
 $app->add(new StopCommand);
+$app->add(new ReloadCommand);
 $app->add(new StatusCommand);
 $app->add(new ConfigCommand());
 $app->run();

--- a/src/Commands/ConfigTrait.php
+++ b/src/Commands/ConfigTrait.php
@@ -30,7 +30,7 @@ trait ConfigTrait
             ->addOption('cgi-path', null, InputOption::VALUE_REQUIRED, 'Full path to the php-cgi executable', false)
             ->addOption('socket-path', null, InputOption::VALUE_REQUIRED, 'Path to a folder where socket files will be placed. Relative to working-directory or cwd()', '.ppm/run/')
             ->addOption('pidfile', null, InputOption::VALUE_REQUIRED, 'Path to a file where the pid of the master process is going to be stored', '.ppm/ppm.pid')
-            ->addOption('reload-threshold', null, InputOption::VALUE_REQUIRED, 'The number of seconds to wait before force closing a worker during a reload, or -1 to disable. Default: 30', 30)
+            ->addOption('reload-timeout', null, InputOption::VALUE_REQUIRED, 'The number of seconds to wait before force closing a worker during a reload, or -1 to disable. Default: 30', 30)
             ->addOption('config', 'c', InputOption::VALUE_REQUIRED, 'Path to config file', '');
     }
 
@@ -98,7 +98,7 @@ trait ConfigTrait
         $config['populate-server-var'] = (boolean)$this->optionOrConfigValue($input, 'populate-server-var', $config);
         $config['socket-path'] = $this->optionOrConfigValue($input, 'socket-path', $config);
         $config['pidfile'] = $this->optionOrConfigValue($input, 'pidfile', $config);
-        $config['reload-threshold'] = $this->optionOrConfigValue($input, 'reload-threshold', $config);
+        $config['reload-timeout'] = $this->optionOrConfigValue($input, 'reload-timeout', $config);
 
         $config['cgi-path'] = $this->optionOrConfigValue($input, 'cgi-path', $config);
 

--- a/src/Commands/ConfigTrait.php
+++ b/src/Commands/ConfigTrait.php
@@ -30,6 +30,7 @@ trait ConfigTrait
             ->addOption('cgi-path', null, InputOption::VALUE_REQUIRED, 'Full path to the php-cgi executable', false)
             ->addOption('socket-path', null, InputOption::VALUE_REQUIRED, 'Path to a folder where socket files will be placed. Relative to working-directory or cwd()', '.ppm/run/')
             ->addOption('pidfile', null, InputOption::VALUE_REQUIRED, 'Path to a file where the pid of the master process is going to be stored', '.ppm/ppm.pid')
+            ->addOption('reload-threshold', null, InputOption::VALUE_REQUIRED, 'The number of seconds to wait before force closing a worker during a reload, or -1 to disable. Default: 30', 30)
             ->addOption('config', 'c', InputOption::VALUE_REQUIRED, 'Path to config file', '');
     }
 
@@ -97,6 +98,7 @@ trait ConfigTrait
         $config['populate-server-var'] = (boolean)$this->optionOrConfigValue($input, 'populate-server-var', $config);
         $config['socket-path'] = $this->optionOrConfigValue($input, 'socket-path', $config);
         $config['pidfile'] = $this->optionOrConfigValue($input, 'pidfile', $config);
+        $config['reload-threshold'] = $this->optionOrConfigValue($input, 'reload-threshold', $config);
 
         $config['cgi-path'] = $this->optionOrConfigValue($input, 'cgi-path', $config);
 

--- a/src/Commands/ReloadCommand.php
+++ b/src/Commands/ReloadCommand.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace PHPPM\Commands;
+
+use PHPPM\ProcessClient;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ReloadCommand extends Command
+{
+    use ConfigTrait;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        parent::configure();
+
+        $this
+            ->setName('reload')
+            ->setDescription('Reloads the server')
+            ->addOption('socket-path', null, InputOption::VALUE_REQUIRED, 'Path to a folder where socket files will be placed. Relative to working-directory or cwd()', '.ppm/run/')
+            ->addArgument('working-directory', InputArgument::OPTIONAL, 'Working directory', './')
+        ;
+
+        $this->configurePPMOptions($this);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $config = $this->initializeConfig($input, $output, false);
+
+        $handler = new ProcessClient();
+        $handler->setSocketPath($config['socket-path']);
+
+        $handler->reloadProcessManager(function($status) use ($output) {
+            $output->writeln('Requested a worker reload.');
+        });
+
+        return null;
+    }
+}

--- a/src/Commands/ReloadCommand.php
+++ b/src/Commands/ReloadCommand.php
@@ -37,7 +37,7 @@ class ReloadCommand extends Command
         $handler = new ProcessClient();
         $handler->setSocketPath($config['socket-path']);
 
-        $handler->reloadProcessManager(function($status) use ($output) {
+        $handler->reloadProcessManager(function ($status) use ($output) {
             $output->writeln('Requested a worker reload.');
         });
 

--- a/src/Commands/ReloadCommand.php
+++ b/src/Commands/ReloadCommand.php
@@ -36,9 +36,8 @@ class ReloadCommand extends Command
 
         $handler = new ProcessClient();
         $handler->setSocketPath($config['socket-path']);
-
         $handler->reloadProcessManager(function ($status) use ($output) {
-            $output->writeln('Requested a worker reload.');
+            $output->writeln("Requested a worker reload.");
         });
 
         return null;

--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -39,7 +39,7 @@ class StartCommand extends Command
         $handler->setBridge($config['bridge']);
         $handler->setAppEnv($config['app-env']);
         $handler->setDebug((boolean)$config['debug']);
-        $handler->setReloadThreshold((int)$config['reload-threshold']);
+        $handler->setReloadTimeout((int)$config['reload-timeout']);
         $handler->setLogging((boolean)$config['logging']);
         $handler->setAppBootstrap($config['bootstrap']);
         $handler->setMaxRequests($config['max-requests']);

--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -39,6 +39,7 @@ class StartCommand extends Command
         $handler->setBridge($config['bridge']);
         $handler->setAppEnv($config['app-env']);
         $handler->setDebug((boolean)$config['debug']);
+        $handler->setReloadThreshold((int)$config['reload-threshold']);
         $handler->setLogging((boolean)$config['logging']);
         $handler->setAppBootstrap($config['bootstrap']);
         $handler->setMaxRequests($config['max-requests']);

--- a/src/ProcessClient.php
+++ b/src/ProcessClient.php
@@ -63,4 +63,11 @@ class ProcessClient
         });
         $this->loop->run();
     }
+
+    public function reloadProcessManager(callable $callback) {
+        $this->request('reload', [], function ($result) use ($callback) {
+            $callback(json_decode($result, true));
+        });
+        $this->loop->run();
+    }
 }

--- a/src/ProcessClient.php
+++ b/src/ProcessClient.php
@@ -64,7 +64,8 @@ class ProcessClient
         $this->loop->run();
     }
 
-    public function reloadProcessManager(callable $callback) {
+    public function reloadProcessManager(callable $callback)
+    {
         $this->request('reload', [], function ($result) use ($callback) {
             $callback(json_decode($result, true));
         });

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -5,6 +5,7 @@ namespace PHPPM;
 
 use React\EventLoop\Factory;
 use React\EventLoop\LoopInterface;
+use React\EventLoop\Timer\TimerInterface;
 use React\Socket\Server;
 use React\Socket\UnixServer;
 use React\Socket\Connection;
@@ -144,7 +145,7 @@ class ProcessManager
     /**
      * Keep track of a single reload timer to prevent multiple reloads spawning several overlapping timers.
      *
-     * @var Timer
+     * @var TimerInterface
      */
     protected $reloadThresholdTimer;
 

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -922,7 +922,6 @@ class ProcessManager
         }
 
         $this->inReload = true;
-
         $this->output->writeln('Restarting all workers');
 
         $this->closeSlaves();

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -565,6 +565,25 @@ class ProcessManager
     }
 
     /**
+     * A slave sent a `reload` command.
+     *
+     * @param array      $data
+     * @param ConnectionInterface $conn
+     */
+    protected function commandReload(array $data, ConnectionInterface $conn)
+    {
+        if ($this->output->isVeryVerbose()) {
+            $conn->on('close', function () {
+                $this->output->writeln('Reload command requested');
+            });
+        }
+
+        $conn->end(json_encode([]));
+
+        $this->restartSlaves();
+    }
+
+    /**
      * A slave sent a `register` command.
      *
      * @param array      $data

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -394,14 +394,16 @@ class ProcessManager
     /**
      * @return int
      */
-    public function getReloadThreshold() {
+    public function getReloadThreshold()
+    {
         return $this->reloadThreshold;
     }
 
     /**
      * @param int $reloadThreshold
      */
-    public function setReloadThreshold($reloadThreshold) {
+    public function setReloadThreshold($reloadThreshold)
+    {
         $this->reloadThreshold = $reloadThreshold;
     }
 
@@ -857,7 +859,8 @@ class ProcessManager
      *
      * @return void
      */
-    protected function closeSlave($slave) {
+    protected function closeSlave($slave)
+    {
         $slave->close();
         $this->slaves->remove($slave);
 
@@ -913,14 +916,14 @@ class ProcessManager
 
                     $this->closeSlave($slave);
                     $this->newSlaveInstance($slave->getPort());
-                } else if ($slave->getStatus() == Slave::BUSY) {
+                } elseif ($slave->getStatus() == Slave::BUSY) {
                     if ($this->output->isVeryVerbose()) {
                         $this->output->writeln(sprintf('Worker #%d is busy, locking', $slave->getPort()));
                     }
 
                     $slave->lock();
                     $busy[] = $slave;
-                } else if ($slave->getStatus() == Slave::LOCKED) {
+                } elseif ($slave->getStatus() == Slave::LOCKED) {
                     $busy[] = $slave;
                 } else {
                     if ($this->output->isVeryVerbose()) {

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -40,6 +40,11 @@ class ProcessManager
      */
     const STATE_SHUTDOWN = 3;
 
+    /*
+     * Load balancer is being reloaded
+     */
+    const STATE_RELOADING = 4;
+
     /**
      * Load balancer status
      */
@@ -455,7 +460,7 @@ class ProcessManager
      */
     public function onSlaveClosed(ConnectionInterface $connection)
     {
-        if ($this->status === self::STATE_SHUTDOWN) {
+        if ($this->status === self::STATE_SHUTDOWN || $this->status === self::STATE_RELOADING) {
             return;
         }
 
@@ -533,6 +538,9 @@ class ProcessManager
             case self::STATE_EMERGENCY:
                 $status = 'offline';
                 break;
+            case self::STATE_RELOADING:
+                $status = 'reloading';
+                break;
             default:
                 $status = 'unknown';
         }
@@ -580,6 +588,7 @@ class ProcessManager
 
         $conn->end(json_encode([]));
 
+        $this->status = self::STATE_RELOADING;
         $this->restartSlaves();
     }
 

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -140,14 +140,14 @@ class ProcessManager
      *
      * @var int
      */
-    protected $reloadThreshold = 30;
+    protected $reloadTimeout = 30;
 
     /**
      * Keep track of a single reload timer to prevent multiple reloads spawning several overlapping timers.
      *
      * @var TimerInterface
      */
-    protected $reloadThresholdTimer;
+    protected $reloadTimeoutTimer;
 
     /**
      * An associative (port->slave) array of slaves currently in a graceful reload phase.
@@ -390,17 +390,17 @@ class ProcessManager
     /**
      * @return int
      */
-    public function getReloadThreshold()
+    public function getReloadTimeout()
     {
-        return $this->reloadThreshold;
+        return $this->reloadTimeout;
     }
 
     /**
-     * @param int $reloadThreshold
+     * @param int $reloadTimeout
      */
-    public function setReloadThreshold($reloadThreshold)
+    public function setReloadTimeout($reloadTimeout)
     {
-        $this->reloadThreshold = $reloadThreshold;
+        $this->reloadTimeout = $reloadTimeout;
     }
 
     /**
@@ -887,13 +887,13 @@ class ProcessManager
     /**
      * Reload all slaves gracefully.
      *
-     * Workers which break the reload-threshold setting will be prematurely terminated.
+     * Workers which break the reload-timeout setting will be prematurely terminated.
      */
     public function reloadSlaves()
     {
         /*
          * NB: we don't lock slave reload with a semaphore, since this could cause
-         * improper reloads when long reload thresholds and multiple code edits are combined.
+         * improper reloads when long reload timeouts and multiple code edits are combined.
          */
 
         $this->output->writeln('<info>Reloading all workers gracefully</info>');
@@ -923,12 +923,12 @@ class ProcessManager
             }
         }
 
-        if ($this->reloadThreshold !== -1) {
-            if ($this->reloadThresholdTimer !== null) {
-                $this->reloadThresholdTimer->cancel();
+        if ($this->reloadTimeout !== -1) {
+            if ($this->reloadTimeoutTimer !== null) {
+                $this->reloadTimeoutTimer->cancel();
             }
 
-            $this->reloadThresholdTimer = $this->loop->addTimer($this->reloadThreshold, function () {
+            $this->reloadTimeoutTimer = $this->loop->addTimer($this->reloadTimeout, function () {
                 if ($this->slavesToReload && $this->output->isVeryVerbose()) {
                     $this->output->writeln('Cleaning up workers that exceeded the graceful reload timeout.');
                 }
@@ -936,7 +936,7 @@ class ProcessManager
                 foreach ($this->slavesToReload as $slave) {
                     $this->output->writeln(
                         sprintf(
-                            '<error>Worker #%d exceeded the graceful reload threshold and was killed.</error>',
+                            '<error>Worker #%d exceeded the graceful reload timeout and was killed.</error>',
                             $slave->getPort()
                         )
                     );

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -140,6 +140,13 @@ class ProcessManager
     protected $inReload = false;
 
     /**
+     * Whether the server is in the restart phase.
+     *
+     * @var bool
+     */
+    protected $inRestart = false;
+
+    /**
      * The number of seconds to wait before force closing a worker during a reload.
      *
      * @var int
@@ -776,7 +783,7 @@ class ProcessManager
      */
     protected function checkChangedFiles($restartSlaves = true)
     {
-        if ($this->inReload) {
+        if ($this->inRestart) {
             return false;
         }
 
@@ -940,17 +947,17 @@ class ProcessManager
      */
     public function restartSlaves()
     {
-        if ($this->inReload) {
+        if ($this->inRestart) {
             return;
         }
 
-        $this->inReload = true;
+        $this->inRestart = true;
         $this->output->writeln('Restarting all workers');
 
         $this->closeSlaves();
         $this->createSlaves();
 
-        $this->inReload = false;
+        $this->inRestart = false;
     }
 
     /**

--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -205,7 +205,7 @@ class RequestHandler
         if ($this->slave->getStatus() === Slave::LOCKED) {
             // slave was locked, so mark as closed now.
             $this->slave->close();
-        } else if ($this->slave->getStatus() !== Slave::CLOSED) {
+        } elseif ($this->slave->getStatus() !== Slave::CLOSED) {
             // if slave has already closed its connection to master,
             // it probably died and is already terminated
 

--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -202,9 +202,13 @@ class RequestHandler
 
         $this->incoming->end();
 
-        // if slave has already closed its connection to master,
-        // it probably died and is already terminated
-        if ($this->slave->getStatus() !== Slave::CLOSED) {
+        if ($this->slave->getStatus() === Slave::LOCKED) {
+            // slave was locked, so mark as closed now.
+            $this->slave->close();
+        } else if ($this->slave->getStatus() !== Slave::CLOSED) {
+            // if slave has already closed its connection to master,
+            // it probably died and is already terminated
+
             // mark slave as available
             $this->slave->release();
 

--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -205,6 +205,8 @@ class RequestHandler
         if ($this->slave->getStatus() === Slave::LOCKED) {
             // slave was locked, so mark as closed now.
             $this->slave->close();
+            $this->output->writeln(sprintf('Reloading worker #%d', $this->slave->getPort()));
+            $this->slave->getConnection()->close();
         } elseif ($this->slave->getStatus() !== Slave::CLOSED) {
             // if slave has already closed its connection to master,
             // it probably died and is already terminated

--- a/src/Slave.php
+++ b/src/Slave.php
@@ -15,6 +15,7 @@ class Slave
      * 3. ready (application bootstrapped)
      * 4. busy (handling request)
      * 5. closed (awaiting termination)
+     * 6. locked (busy, but gracefully awaiting termination)
      */
 
     const ANY = 0;
@@ -23,6 +24,7 @@ class Slave
     const READY = 3;
     const BUSY = 4;
     const CLOSED = 5;
+    const LOCKED = 6;
 
     protected $socketPath;
 
@@ -148,6 +150,19 @@ class Slave
     public function close()
     {
         $this->status = self::CLOSED;
+    }
+
+    /**
+     * Lock slave
+     *
+     * Locked slaves are closed for new requests, but is finishing the current
+     * request gracefully as to not interrupt the response lifecycle.
+     *
+     * @return void
+     */
+    public function lock()
+    {
+        $this->status = self::LOCKED;
     }
 
     /**

--- a/src/Slave.php
+++ b/src/Slave.php
@@ -162,6 +162,10 @@ class Slave
      */
     public function lock()
     {
+        if ($this->status !== self::BUSY) {
+            throw new \LogicException('Cannot lock a slave that is not in busy state');
+        }
+
         $this->status = self::LOCKED;
     }
 

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -6,7 +6,6 @@ use PHPPM\Utils;
 
 class UtilsTest extends PhpPmTestCase
 {
-
     public function providePaths()
     {
         return [
@@ -33,5 +32,4 @@ class UtilsTest extends PhpPmTestCase
     {
         $this->assertEquals($expected, Utils::parseQueryPath($path));
     }
-
 }


### PR DESCRIPTION
What was missing was a function to reload the workers in a production setting a la debug hot code reload, however I don't like that since it kills any ongoing requests, which might have consequences...

This is a summary of the changes:

- Adds the `reload` command, which performs a graceful **in-place** reload that waits for workers to finish. Workers are replaced as soon as they are not in a busy state.
- So the above can work, slaves will enter a "locked" state if discovered to be busy during the reload loop, to stop them from returning to a ready state.
- Adds the `reload-threshold` setting, which will determine for how long in seconds a graceful reload is attempted before the worker is outright killed. Defaults at 30, -1 to disable.
- Makes a distinction between reload and restart in code, to be more in line with how this terminology is used. `restartSlaves` was using a `inReload` semaphore; this has been changed to `inRestart`.