### PR TITLE
Hotfix: Servers with many workers stuck in starting phase

### DIFF
--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -539,7 +539,14 @@ class ProcessManager
 
         $conn->end(json_encode([
             'status' => $status,
-            'workers' => $this->slaveCount,
+            'workers' => [
+                'total' => count($this->slaves->getByStatus(Slave::ANY)),
+                'ready' => count($this->slaves->getByStatus(Slave::READY)),
+                'busy' => count($this->slaves->getByStatus(Slave::BUSY)),
+                'created' => count($this->slaves->getByStatus(Slave::CREATED)),
+                'registered' => count($this->slaves->getByStatus(Slave::REGISTERED)),
+                'closed' => count($this->slaves->getByStatus(Slave::CLOSED))
+            ],
             'handled_requests' => $this->handledRequests,
             'handled_requests_per_worker' => $requests
         ]));
@@ -606,6 +613,11 @@ class ProcessManager
         try {
             $slave = $this->slaves->getByConnection($conn);
         } catch (\Exception $e) {
+            $this->output->writeln(
+                '<error>A ready command was sent by a worker with no connection. This was unexpected. ' .
+                'Not your fault, please create a ticket at github.com/php-pm/php-pm with ' .
+                'the output of `ppm start -vv`.</error>'
+            );
             return;
         }
 

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -845,7 +845,8 @@ class ProcessManager
     {
         if ($this->status === self::STATE_STARTING || $this->status === self::STATE_EMERGENCY) {
             $readySlaves = $this->slaves->getByStatus(Slave::READY);
-            return count($readySlaves) === $this->slaveCount;
+            $busySlaves = $this->slaves->getByStatus(Slave::BUSY);
+            return count($readySlaves) + count($busySlaves) === $this->slaveCount;
         }
 
         return false;

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -539,14 +539,7 @@ class ProcessManager
 
         $conn->end(json_encode([
             'status' => $status,
-            'workers' => [
-                'total' => count($this->slaves->getByStatus(Slave::ANY)),
-                'ready' => count($this->slaves->getByStatus(Slave::READY)),
-                'busy' => count($this->slaves->getByStatus(Slave::BUSY)),
-                'created' => count($this->slaves->getByStatus(Slave::CREATED)),
-                'registered' => count($this->slaves->getByStatus(Slave::REGISTERED)),
-                'closed' => count($this->slaves->getByStatus(Slave::CLOSED))
-            ],
+            'workers' => $this->slaves->getStatusSummary(),
             'handled_requests' => $this->handledRequests,
             'handled_requests_per_worker' => $requests
         ]));

--- a/src/ProcessSlave.php
+++ b/src/ProcessSlave.php
@@ -287,54 +287,67 @@ class ProcessSlave
     }
 
     /**
+     * Attempt a connection to the unix socket.
+     *
+     * @throws \RuntimeException
+     */
+    private function doConnect()
+    {
+        $connector = new UnixConnector($this->loop);
+        $unixSocket = $this->getControllerSocketPath(false);
+
+        $connector->connect($unixSocket)->done(
+            function ($controller) {
+                $this->controller = $controller;
+
+                $pcntl = new PCNTL($this->loop);
+                $pcntl->on(SIGTERM, [$this, 'shutdown']);
+                $pcntl->on(SIGINT, [$this, 'shutdown']);
+                register_shutdown_function([$this, 'shutdown']);
+
+                $this->bindProcessMessage($this->controller);
+                $this->controller->on('close', [$this, 'shutdown']);
+
+                // port is the slave identifier
+                $port = $this->config['port'];
+                $socketPath = $this->getSlaveSocketPath($port, true);
+                $this->server = new UnixServer($socketPath, $this->loop);
+
+                $httpServer = new HttpServer([$this, 'onRequest']);
+                $httpServer->listen($this->server);
+
+                $this->sendMessage($this->controller, 'register', ['pid' => getmypid(), 'port' => $port]);
+            }
+        );
+    }
+
+    /**
+     * Attempt a connection through the unix socket until it succeeds.
+     * This is a workaround for an issue where the (hardcoded) 1s socket timeout is triggered due to a busy socket.
+     */
+    private function tryConnect()
+    {
+        try {
+            $this->doConnect();
+        } catch (\RuntimeException $ex) {
+            // Failed to connect to the controller, there was probably a timeout accessing the socket...
+            $this->loop->addTimer(1, function () {
+                $this->tryConnect();
+            });
+        }
+    }
+
+    /**
      * Connects to ProcessManager, master process.
      */
     public function run()
     {
-        if (!$this->loop) {
-            $this->loop = Factory::create();
-        }
+        $this->loop = Factory::create();
 
         $this->errorLogger = BufferingLogger::create();
         ErrorHandler::register(new ErrorHandler($this->errorLogger));
 
-        $connector = new UnixConnector($this->loop);
-        $unixSocket = $this->getControllerSocketPath(false);
-
-        try {
-            $connector->connect($unixSocket)->done(
-                function ($controller) {
-                    $this->controller = $controller;
-
-                    $pcntl = new PCNTL($this->loop);
-                    $pcntl->on(SIGTERM, [$this, 'shutdown']);
-                    $pcntl->on(SIGINT, [$this, 'shutdown']);
-                    register_shutdown_function([$this, 'shutdown']);
-
-                    $this->bindProcessMessage($this->controller);
-                    $this->controller->on('close', [$this, 'shutdown']);
-
-                    // port is the slave identifier
-                    $port = $this->config['port'];
-                    $socketPath = $this->getSlaveSocketPath($port, true);
-                    $this->server = new UnixServer($socketPath, $this->loop);
-
-                    $httpServer = new HttpServer([$this, 'onRequest']);
-                    $httpServer->listen($this->server);
-
-                    $this->sendMessage($this->controller, 'register', ['pid' => getmypid(), 'port' => $port]);
-                }
-            );
-        } catch (\RuntimeException $ex) {
-            // Failed to connect to the controller, there was probably a timeout accessing the socket...
-            // Unfortunately we can't specify the socket timeout so we'll do this for now.
-            error_log("Worker {$this->config['port']} was unable to connect to the socket (busy?) retrying.");
-
-            $this->loop->addTimer(1, function () {
-                $this->run();
-            });
-        }
-
+        $this->tryConnect();
         $this->loop->run();
     }
 

--- a/src/SlavePool.php
+++ b/src/SlavePool.php
@@ -82,7 +82,7 @@ class SlavePool
         $hash = spl_object_hash($connection);
 
         foreach ($this->slaves as $slave) {
-            if ($hash === spl_object_hash($slave->getConnection())) {
+            if ($slave->getConnection() && $hash === spl_object_hash($slave->getConnection())) {
                 return $slave;
             }
         }

--- a/src/SlavePool.php
+++ b/src/SlavePool.php
@@ -99,4 +99,25 @@ class SlavePool
             return $status === Slave::ANY || $status === $slave->getStatus();
         });
     }
+
+    /**
+     * Return a human-readable summary of the slaves in the pool.
+     *
+     * @return array
+     */
+    public function getStatusSummary()
+    {
+        $map = [
+            'total' => Slave::ANY,
+            'ready' => Slave::READY,
+            'busy' => Slave::BUSY,
+            'created' => Slave::CREATED,
+            'registered' => Slave::REGISTERED,
+            'closed' => Slave::CLOSED
+        ];
+
+        return array_map(function ($state) {
+            return count($this->getByStatus($state));
+        }, $map);
+    }
 }


### PR DESCRIPTION
If the controller unix socket is too busy (e.g. you have a high worker count * bootstrap time) the slave will hit a RuntimeException and keep the server stuck in a starting phase. This change makes sure the slave retries the connection until it succeeds.