### PR TITLE
Fix work with LibEventLoop (remove event-loop stream wrapper from fop…

### DIFF
--- a/src/ProcessSlave.php
+++ b/src/ProcessSlave.php
@@ -498,7 +498,7 @@ class ProcessSlave
                 'Cache-Control' => 'max-age=' . $expires,
                 'Last-Modified' => gmdate('D, d M Y H:i:s', $mTime) . ' GMT',
                 'Expires' => gmdate('D, d M Y H:i:s', time() + $expires) . ' GMT'
-            ], new ReadableResourceStream(fopen($filePath, 'rb'), $this->loop));
+            ], fopen($filePath, 'rb'));
 
             return $response;
         }


### PR DESCRIPTION
…en stream)

Hi, trouble in serveStatic with LibEventLoop loop mode. At moment a stream create from file and attach to event-loop (event_add call).

This is equal with this code:

$base = event_base_new();
$event = event_new();
event_set($event, fopen('/tmp/text.txt', 'rb'), EV_PERSIST | EV_READ, function() {});
event_base_set($event, $base);
event_add($event);

If run it - we getting errors:

[warn] Epoll ADD(1) on fd 9 failed.  Old events were 0; read change was 1 (add); write change was 0 (none): Operation not permitted

In trace:

open("/tmp/text.txt", O_RDONLY) = 9
fstat(9, {st_mode=S_IFREG|0644, st_size=78584, ...}) = 0
lseek(9, 0, SEEK_CUR)                   = 0
epoll_ctl(6, EPOLL_CTL_ADD, 9, {EPOLLIN, {u32=9, u64=9}}) = -1 EPERM (Operation not permitted)
write(2, "[warn] Epoll ADD(1) on fd 9 fail"..., 132[warn] Epoll ADD(1) on fd 9 failed.  Old events were 0; read change was 1 (add); write change was 0 (none): Operation not permitted

From epoll documentation:
https://www.systutorials.com/docs/linux/man/2-epoll_ctl/
EPERM
The target file fd does not support epoll.

As a result - a regular file can not be used with epoll.

So, this is not need here. We need to get a stream for the file and do not bind it to epoll. Thus, we need a fopen stream resource.


\RingCentral\Psr7\Response::__construct:

        if ($body !== null) {
            $this->stream = stream_for($body);
        }

=>

        case 'resource':
            return new Stream($resource, $options);

In fact, what we need. StreamSelectLoop does not consider this an error, but also does not use.

With this change, the code became compatible with all loops (StreamSelectLoop, LibEventLoop).

Thanks :)

