### PR TITLE
Add better logging for disabled PCNTL extensions

### DIFF
--- a/bin/ppm
+++ b/bin/ppm
@@ -18,8 +18,17 @@ if ((!$loader = includeIfExists(__DIR__.'/../vendor/autoload.php')) && (!$loader
     );
 }
 
+if (!PHPPM\pcntl_installed()) {
+    die(
+        sprintf(
+            'PCNTL is not enabled in the PHP installation at %s. See: http://php.net/manual/en/pcntl.installation.php',
+            PHP_BINARY
+        )
+    );
+}
+
 if (!PHPPM\pcntl_enabled()) {
-    die('Some of required pcntl functions are disabled. Check `disable_functions` setting in `php.ini`.');
+    die('Some required PCNTL functions are disabled. Check `disabled_functions` in `php.ini`.');
 }
 
 use Symfony\Component\Console\Application;

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -885,18 +885,18 @@ require_once file_exists($dir . '/vendor/autoload.php')
     ? $dir . '/vendor/autoload.php'
     : $dir . '/../../autoload.php';
     
-if (!pcntl_enabled()) {
+if (!pcntl_installed()) {
     error_log(
         sprintf(
-            'PCNTL is not enabled in PHP installation at %s. See: http://php.net/manual/en/pcntl.installation.php',
+            'PCNTL is not enabled in the PHP installation at %s. See: http://php.net/manual/en/pcntl.installation.php',
             PHP_BINARY
         )
     );
     exit();
 }
 
-if (!pcntl_available()) {
-    error_log('It appears that PCNTL functions have been disabled. Check `disabled_functions` in `php.ini`.');
+if (!pcntl_enabled()) {
+    error_log('Some required PCNTL functions are disabled. Check `disabled_functions` in `php.ini`.');
     exit();
 }
 

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -884,9 +884,20 @@ set_time_limit(0);
 require_once file_exists($dir . '/vendor/autoload.php')
     ? $dir . '/vendor/autoload.php'
     : $dir . '/../../autoload.php';
-
+    
 if (!pcntl_enabled()) {
-    throw new \RuntimeException('Some of required pcntl functions are disabled. Check `disable_functions` setting in `php.ini`.');
+    error_log(
+        sprintf(
+            'PCNTL is not enabled in PHP installation at %s. See: http://php.net/manual/en/pcntl.installation.php',
+            PHP_BINARY
+        )
+    );
+    exit();
+}
+
+if (!pcntl_available()) {
+    error_log('It appears that PCNTL functions have been disabled. Check `disabled_functions` in `php.ini`.');
+    exit();
 }
 
 //global for all global functions

--- a/src/functions.php
+++ b/src/functions.php
@@ -30,11 +30,21 @@ function console_log($expression, $_ = null)
 }
 
 /**
- * Checks that all required pcntl functions are available, so not fatal errors would be cause in runtime
+ * Checks that PCNTL is actually enabled in this installation.
  *
  * @return bool
  */
 function pcntl_enabled()
+{
+    return function_exists('pcntl_signal');
+}
+
+/**
+ * Makes sure required PCNTL functions aren't included in disable_functions.
+ *
+ * @return bool
+ */
+function pcntl_available()
 {
     $requiredFunctions = ['pcntl_signal', 'pcntl_signal_dispatch', 'pcntl_waitpid'];
     $disabledFunctions = explode(',', (string) ini_get('disable_functions'));

--- a/src/functions.php
+++ b/src/functions.php
@@ -34,7 +34,7 @@ function console_log($expression, $_ = null)
  *
  * @return bool
  */
-function pcntl_enabled()
+function pcntl_installed()
 {
     return function_exists('pcntl_signal');
 }
@@ -44,7 +44,7 @@ function pcntl_enabled()
  *
  * @return bool
  */
-function pcntl_available()
+function pcntl_enabled()
 {
     $requiredFunctions = ['pcntl_signal', 'pcntl_signal_dispatch', 'pcntl_waitpid'];
     $disabledFunctions = explode(',', (string) ini_get('disable_functions'));


### PR DESCRIPTION
Came across this issue on my laptop when accidentally using a non-PCNTL PHP install; ppm worker would fail silently. Checks to see if the PCNTL functions actually exist, before doing the `disabled_functions` check.

The thrown RuntimeException won't display in the server log, so that too has been altered until we have a better logging solution.