### PR TITLE
Worker TTL

### DIFF
--- a/src/Commands/ConfigTrait.php
+++ b/src/Commands/ConfigTrait.php
@@ -25,6 +25,7 @@ trait ConfigTrait
             ->addOption('logging', null, InputOption::VALUE_REQUIRED, 'Enable/Disable http logging to stdout. 1|0', 1)
             ->addOption('static-directory', null, InputOption::VALUE_REQUIRED, 'Static files root directory, if not provided static files will not be served', '')
             ->addOption('max-requests', null, InputOption::VALUE_REQUIRED, 'Max requests per worker until it will be restarted', 1000)
+            ->addOption('ttl', null, InputOption::VALUE_REQUIRED, 'Time to live for a worker until it will be restarted', null)
             ->addOption('populate-server-var', null, InputOption::VALUE_REQUIRED, 'If a worker application uses $_SERVER var it needs to be populated by request data 1|0', 1)
             ->addOption('bootstrap', null, InputOption::VALUE_REQUIRED, 'Class responsible for bootstrapping the application', 'PHPPM\Bootstraps\Symfony')
             ->addOption('cgi-path', null, InputOption::VALUE_REQUIRED, 'Full path to the php-cgi executable', false)

--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -41,6 +41,7 @@ class StartCommand extends Command
         $handler->setLogging((boolean)$config['logging']);
         $handler->setAppBootstrap($config['bootstrap']);
         $handler->setMaxRequests($config['max-requests']);
+        $handler->setTtl($config['ttl']);
         $handler->setPhpCgiExecutable($config['cgi-path']);
         $handler->setSocketPath($config['socket-path']);
         $handler->setPIDFile($config['pidfile']);

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -64,6 +64,13 @@ class ProcessManager
     protected $maxRequests = 2000;
 
     /**
+     * Worker time to live
+     *
+     * @var int|null
+     */
+    protected $ttl;
+
+    /**
      * @var SlavePool
      */
     protected $slaves;
@@ -309,6 +316,14 @@ class ProcessManager
     public function setMaxRequests($maxRequests)
     {
         $this->maxRequests = $maxRequests;
+    }
+
+    /**
+     * @param int $ttl
+     */
+    public function setTtl($ttl)
+    {
+        $this->ttl = $ttl;
     }
 
     /**
@@ -1160,7 +1175,7 @@ EOF;
         // use exec to omit wrapping shell
         $process = new Process($commandline);
 
-        $slave = new Slave($port, $this->maxRequests);
+        $slave = new Slave($port, $this->maxRequests, $this->ttl);
         $slave->attach($process);
         $this->slaves->add($slave);
 

--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -137,6 +137,13 @@ class RequestHandler
      */
     public function slaveAvailable(Slave $slave)
     {
+        if ($slave->isExpired()) {
+            $slave->close();
+            $this->output->writeln(sprintf('Restart worker #%d because it reached its TTL', $slave->getPort()));
+            $slave->getConnection()->close();
+            return;
+        }
+
         $this->redirectionTries++;
 
         // client went away while waiting for worker

--- a/src/Slave.php
+++ b/src/Slave.php
@@ -58,10 +58,26 @@ class Slave
      */
     private $handledRequests = 0;
 
-    public function __construct($port, $maxRequests)
+    /**
+     * Time to live
+     *
+     * @var int|null
+     */
+    private $ttl;
+
+    /**
+     * Start timestamp
+     *
+     * @var int
+     */
+    private $startedAt;
+
+    public function __construct($port, $maxRequests, $ttl = null)
     {
         $this->port = $port;
         $this->maxRequests = $maxRequests;
+        $this->ttl = $ttl;
+        $this->startedAt = time();
 
         $this->status = self::CREATED;
     }
@@ -237,6 +253,14 @@ class Slave
     public function getMaxRequests()
     {
         return $this->maxRequests;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function isExpired()
+    {
+        return null !== $this->ttl && time() >= ($this->startedAt + $this->ttl);
     }
 
     /**


### PR DESCRIPTION
Following #391 

This PR is a proof of concept which adds a `ttl` option that may, or may not, be used in `ppm.json`. 
When a request comes in, the worker must not have outrun its time to live, or it will be reloaded.

This is the first time I dive into the PPM code, please review & test this before merging.

Thank you,
Ben