### PR TITLE
Handle slave not becoming available in due time and slave sending empty response

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,17 @@ script:
   - ./vendor/bin/phpunit
   # Integration test
   - mkdir web && echo "Hello" > web/index.html
-  - bin/ppm start --workers=1 --bridge=PHPPM\\Tests\\TestBridge --static-directory=web --max-requests=1 -v &
+  - bin/ppm start --workers=1 --bridge=StaticBridge --static-directory=web --max-requests=1 -v &
   - sleep 5
   - bin/ppm status
   - curl -v -f "http://127.0.0.1:8080"
   - bin/ppm status
   - curl -v -f "http://127.0.0.1:8080"
   - bin/ppm status
+  - bin/ppm stop
   # Trigger 502 error by triggering an exit() in the worker
+  - bin/ppm start --workers=1 --bridge=PHPPM\\Tests\\TestBridge --static-directory=web --max-requests=1 -v &
+  - sleep 5
   - bash -c 'if [[ $(curl --write-out %{http_code} --silent --output /dev/null "http://127.0.0.1:8080/test?exit_prematurely=1") == "502" ]]; then exit 0; else exit 1; fi'
   - bin/ppm status
   # Trigger 503 error by tying up the worker and making a second request

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,19 @@ script:
   - ./vendor/bin/phpunit
   # Integration test
   - mkdir web && echo "Hello" > web/index.html
-  - bin/ppm start --workers=1 --bridge=StaticBridge --static-directory=web --max-requests=1 -v &
+  - bin/ppm start --workers=1 --bridge=PHPPM\\Tests\\TestBridge --static-directory=web --max-requests=1 -v &
   - sleep 5
   - bin/ppm status
   - curl -v -f "http://127.0.0.1:8080"
   - bin/ppm status
   - curl -v -f "http://127.0.0.1:8080"
+  - bin/ppm status
+  # Trigger 502 error by triggering an exit() in the worker
+  - bash -c 'if [[ $(curl --write-out %{http_code} --silent --output /dev/null "http://127.0.0.1:8080/test?exit_prematurely=1") == "502" ]]; then exit 0; else exit 1; fi'
+  - bin/ppm status
+  # Trigger 503 error by tying up the worker and making a second request
+  - curl -f --silent "http://127.0.0.1:8080/test?sleep=10000" &
+  - bash -c 'if [[ $(curl --write-out %{http_code} --silent --output /dev/null "http://127.0.0.1:8080") == "503" ]]; then exit 0; else exit 1; fi'
   - bin/ppm status
   - bin/ppm stop
 

--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -18,6 +18,11 @@ class RequestHandler
     protected $start;
 
     /**
+     * @var float
+     */
+    protected $requestSentAt;
+
+    /**
      * @var ConnectionInterface
      */
     private $incoming;
@@ -57,6 +62,7 @@ class RequestHandler
     private $connectionOpen = true;
     private $redirectionTries = 0;
     private $incomingBuffer = '';
+    private $lastOutgoingData = ''; // Used to track abnormal responses
 
     public function __construct($socketPath, LoopInterface $loop, OutputInterface $output, SlavePool $slaves)
     {
@@ -82,6 +88,7 @@ class RequestHandler
         });
 
         $this->start = microtime(true);
+        $this->requestSentAt = microtime(true);
         $this->getNextSlave();
     }
 
@@ -127,9 +134,31 @@ class RequestHandler
                 return $this->getNextSlave();
             }
         } else {
-            // keep retrying until slave becomes available
-            $this->loop->futureTick([$this, 'getNextSlave']);
+            // keep retrying until slave becomes available, unless timeout has been exceeded
+            if(time() < ($this->requestSentAt + $this->timeout)) {
+                $this->loop->futureTick([$this, 'getNextSlave']);
+            } else {
+                // Return a "503 Service Unavailable" response
+                $this->output->writeln(sprintf('No slaves available to handle the request and timeout %d seconds exceeded', $this->timeout));
+                $this->incoming->write($this->createErrorResponse('503 Service Temporarily Unavailable', 'Service Temporarily Unavailable'));
+                $this->incoming->end();
+            }
         }
+    }
+
+    private function createErrorResponse($code, $text) {
+        return sprintf(
+            'HTTP/1.1 %s'."\n".
+            'Date: %s'."\n".
+            'Content-Type: text/plain'."\n".
+            'Content-Length: %s'."\n".
+            "\n".
+            '%s',
+            $code,
+            gmdate('D, d M Y H:i:s T'),
+            strlen($text),
+            $text
+        );
     }
 
     /**
@@ -196,8 +225,13 @@ class RequestHandler
         // update slave availability
         $this->connection->on('close', [$this, 'slaveClosed']);
 
+        // keep track of the last sent data to detect if slave exited abnormally
+        $this->connection->on('data', function ($data) {
+            $this->lastOutgoingData = $data;
+        });
+
         // relay data to client
-        $this->connection->pipe($this->incoming);
+        $this->connection->pipe($this->incoming, array('end' => false));
     }
 
     /**
@@ -211,6 +245,11 @@ class RequestHandler
             return sprintf('<info>Worker %d took abnormal %.3f seconds for handling a connection</info>', $this->slave->getPort(), $took);
         });
 
+        // Return a "502 Bad Gateway" response if the response was empty
+        if($this->lastOutgoingData == '') {
+            $this->output->writeln('Slave returned an invalid HTTP response. Maybe the script has called exit() prematurely?');
+            $this->incoming->write($this->createErrorResponse('502 Bad Gateway', 'Slave returned an invalid HTTP response. Maybe the script has called exit() prematurely?'));
+        }
         $this->incoming->end();
 
         if ($this->slave->getStatus() === Slave::LOCKED) {

--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -135,7 +135,7 @@ class RequestHandler
             }
         } else {
             // keep retrying until slave becomes available, unless timeout has been exceeded
-            if(time() < ($this->requestSentAt + $this->timeout)) {
+            if (time() < ($this->requestSentAt + $this->timeout)) {
                 $this->loop->futureTick([$this, 'getNextSlave']);
             } else {
                 // Return a "503 Service Unavailable" response
@@ -146,7 +146,8 @@ class RequestHandler
         }
     }
 
-    private function createErrorResponse($code, $text) {
+    private function createErrorResponse($code, $text)
+    {
         return sprintf(
             'HTTP/1.1 %s'."\n".
             'Date: %s'."\n".
@@ -231,7 +232,7 @@ class RequestHandler
         });
 
         // relay data to client
-        $this->connection->pipe($this->incoming, array('end' => false));
+        $this->connection->pipe($this->incoming, ['end' => false]);
     }
 
     /**
@@ -246,8 +247,8 @@ class RequestHandler
         });
 
         // Return a "502 Bad Gateway" response if the response was empty
-        if($this->lastOutgoingData == '') {
-            $this->output->writeln('Slave returned an invalid HTTP response. Maybe the script has called exit() prematurely?');
+        if ($this->lastOutgoingData == '') {
+            $this->output->writeln('Script did not return a valid HTTP response. Maybe it has called exit() prematurely?');
             $this->incoming->write($this->createErrorResponse('502 Bad Gateway', 'Slave returned an invalid HTTP response. Maybe the script has called exit() prematurely?'));
         }
         $this->incoming->end();

--- a/tests/TestBridge.php
+++ b/tests/TestBridge.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace PHPPM\Tests;
+
+use Psr\Http\Message\ServerRequestInterface;
+use RingCentral\Psr7;
+use PHPPM\Bridges\StaticBridge;
+
+class TestBridge extends StaticBridge
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(ServerRequestInterface $request)
+    {
+
+        $params = $request->getQueryParams();
+        if(@$params['exit_prematurely'] == '1') {
+            exit();
+        }
+        if(isset($params['sleep'])) {
+            sleep($params['sleep']);
+        }
+        return new Psr7\Response(404, ['Content-type' => 'text/plain'], 'Not found');
+    }
+}


### PR DESCRIPTION
This PR tries to fix some of the issues from https://github.com/php-pm/php-pm/issues/110, specifically the cases:

- slave connection errors (i.e. if no slave becomes available in due time) - *We now throw a "503 Service Unavailable" error in this case.  I used the RequestHandler timeout attribute but maybe the timeout should be configurable?*
- slave calls exit(), times out or in general crashes without sending a valid response - *We now throw a "502 Bad Gateway" error*