### PR TITLE
Add max execution time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,16 @@ script:
   - bin/ppm status
   - bin/ppm stop
   # Trigger 502 error by triggering an exit() in the worker
-  - bin/ppm start --workers=1 --bridge=PHPPM\\Tests\\TestBridge --static-directory=web --max-requests=1 -v &
+  - bin/ppm start --workers=1 --bridge=PHPPM\\Tests\\TestBridge --static-directory=web --max-requests=1 --max-execution-time=15 -v &
   - sleep 5
   - bash -c 'if [[ $(curl --write-out %{http_code} --silent --output /dev/null "http://127.0.0.1:8080/test?exit_prematurely=1") == "502" ]]; then exit 0; else exit 1; fi'
   - bin/ppm status
   # Trigger 503 error by tying up the worker and making a second request
   - curl -f --silent "http://127.0.0.1:8080/test?sleep=10000" &
   - bash -c 'if [[ $(curl --write-out %{http_code} --silent --output /dev/null "http://127.0.0.1:8080") == "503" ]]; then exit 0; else exit 1; fi'
+  - bin/ppm status
+  # Trigger 504 error by making a sleep request and waiting until the timeout
+  - bash -c 'if [[ $(curl --write-out %{http_code} --silent --output /dev/null "http://127.0.0.1:8080/test?sleep=10000") == "504" ]]; then exit 0; else exit 1; fi'
   - bin/ppm status
   - bin/ppm stop
 

--- a/src/Commands/ConfigTrait.php
+++ b/src/Commands/ConfigTrait.php
@@ -25,6 +25,7 @@ trait ConfigTrait
             ->addOption('logging', null, InputOption::VALUE_REQUIRED, 'Enable/Disable http logging to stdout. 1|0', 1)
             ->addOption('static-directory', null, InputOption::VALUE_REQUIRED, 'Static files root directory, if not provided static files will not be served', '')
             ->addOption('max-requests', null, InputOption::VALUE_REQUIRED, 'Max requests per worker until it will be restarted', 1000)
+            ->addOption('max-execution-time', null, InputOption::VALUE_REQUIRED, 'Maximum amount of time a request is allowed to execute before shutting down', 30)
             ->addOption('ttl', null, InputOption::VALUE_REQUIRED, 'Time to live for a worker until it will be restarted', null)
             ->addOption('populate-server-var', null, InputOption::VALUE_REQUIRED, 'If a worker application uses $_SERVER var it needs to be populated by request data 1|0', 1)
             ->addOption('bootstrap', null, InputOption::VALUE_REQUIRED, 'Class responsible for bootstrapping the application', 'PHPPM\Bootstraps\Symfony')
@@ -96,6 +97,7 @@ trait ConfigTrait
         $config['static-directory'] = $this->optionOrConfigValue($input, 'static-directory', $config);
         $config['bootstrap'] = $this->optionOrConfigValue($input, 'bootstrap', $config);
         $config['max-requests'] = (int)$this->optionOrConfigValue($input, 'max-requests', $config);
+        $config['max-execution-time'] = (int)$this->optionOrConfigValue($input, 'max-execution-time', $config);
         $config['ttl'] = (int)$this->optionOrConfigValue($input, 'ttl', $config);
         $config['populate-server-var'] = (boolean)$this->optionOrConfigValue($input, 'populate-server-var', $config);
         $config['socket-path'] = $this->optionOrConfigValue($input, 'socket-path', $config);

--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -41,6 +41,7 @@ class StartCommand extends Command
         $handler->setLogging((boolean)$config['logging']);
         $handler->setAppBootstrap($config['bootstrap']);
         $handler->setMaxRequests($config['max-requests']);
+        $handler->setMaxExecutionTime($config['max-execution-time']);
         $handler->setTtl($config['ttl']);
         $handler->setPhpCgiExecutable($config['cgi-path']);
         $handler->setSocketPath($config['socket-path']);

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -64,6 +64,13 @@ class ProcessManager
     protected $maxRequests = 2000;
 
     /**
+     * Maximum amount of time a request is allowed to execute before shutting down
+     *
+     * @var int
+     */
+    protected $maxExecutionTime = 30;
+
+    /**
      * Worker time to live
      *
      * @var int|null
@@ -318,6 +325,14 @@ class ProcessManager
     }
 
     /**
+     * @param int $maxExecutionTime
+     */
+    public function setMaxExecutionTime($maxExecutionTime)
+    {
+        $this->maxExecutionTime = $maxExecutionTime;
+    }
+
+    /**
      * @param int $ttl
      */
     public function setTtl($ttl)
@@ -514,7 +529,7 @@ class ProcessManager
     {
         $this->handledRequests++;
 
-        $handler = new RequestHandler($this->socketPath, $this->loop, $this->output, $this->slaves);
+        $handler = new RequestHandler($this->socketPath, $this->loop, $this->output, $this->slaves, $this->maxExecutionTime);
         $handler->handle($incoming);
     }
 

--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -3,6 +3,7 @@
 namespace PHPPM;
 
 use React\EventLoop\LoopInterface;
+use React\EventLoop\TimerInterface;
 use React\Socket\UnixConnector;
 use React\Socket\TimeoutConnector;
 use React\Socket\ConnectionInterface;
@@ -55,6 +56,20 @@ class RequestHandler
     private $timeout = 10;
 
     /**
+     * Max amount of time a script is allowed to run in the worker before closing.
+     *
+     * @var int
+     */
+    private $maxExecutionTime;
+
+    /**
+     * Timer that handles stopping the worker if script has excceed the max execution time
+     *
+     * @var TimerInterface
+     */
+    private $maxExecutionTimer;
+
+    /**
      * @var Slave instance
      */
     private $slave;
@@ -64,13 +79,14 @@ class RequestHandler
     private $incomingBuffer = '';
     private $lastOutgoingData = ''; // Used to track abnormal responses
 
-    public function __construct($socketPath, LoopInterface $loop, OutputInterface $output, SlavePool $slaves)
+    public function __construct($socketPath, LoopInterface $loop, OutputInterface $output, SlavePool $slaves, $maxExecutionTime)
     {
         $this->setSocketPath($socketPath);
 
         $this->loop = $loop;
         $this->output = $output;
         $this->slaves = $slaves;
+        $this->maxExecutionTime = $maxExecutionTime;
     }
 
     /**
@@ -86,6 +102,9 @@ class RequestHandler
         $this->incoming->on('close', function () {
             $this->connectionOpen = false;
         });
+        if($this->maxExecutionTime > 0) {
+            $this->maxExecutionTimer = $this->loop->addTimer($this->maxExecutionTime, [$this, 'maxExecutionTimeExceeded']);
+        }
 
         $this->start = microtime(true);
         $this->requestSentAt = microtime(true);
@@ -236,6 +255,26 @@ class RequestHandler
     }
 
     /**
+     * Stop the worker if the max execution time has been exceeded and return 504
+     */
+    public function maxExecutionTimeExceeded()
+    {
+        // client went away while waiting for worker
+        if (!$this->connectionOpen) {
+            return false;
+        }
+
+        $response = $this->createErrorResponse('504 Gateway Timeout', 'Maximum execution time exceeded');
+        $this->incoming->write($response);
+        $this->lastOutgoingData = $response;
+
+        // mark slave as closed
+        $this->slave->close();
+        $this->output->writeln(sprintf('Maximum execution time of %d seconds exceeded. Closing worker.', $this->maxExecutionTime));
+        $this->slave->getConnection()->close();
+    }
+
+    /**
      * Handle slave disconnected
      *
      * Typically called after slave has finished handling request
@@ -252,6 +291,9 @@ class RequestHandler
             $this->incoming->write($this->createErrorResponse('502 Bad Gateway', 'Slave returned an invalid HTTP response. Maybe the script has called exit() prematurely?'));
         }
         $this->incoming->end();
+        if($this->maxExecutionTime > 0) {
+            $this->loop->cancelTimer($this->maxExecutionTimer);
+        }
 
         if ($this->slave->getStatus() === Slave::LOCKED) {
             // slave was locked, so mark as closed now.

--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -264,9 +264,8 @@ class RequestHandler
             return false;
         }
 
-        $response = $this->createErrorResponse('504 Gateway Timeout', 'Maximum execution time exceeded');
-        $this->incoming->write($response);
-        $this->lastOutgoingData = $response;
+        $this->incoming->write($this->createErrorResponse('504 Gateway Timeout', 'Maximum execution time exceeded'));
+        $this->lastOutgoingData = 'not empty'; // Avoid triggering 502
 
         // mark slave as closed
         $this->slave->close();

--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -102,7 +102,7 @@ class RequestHandler
         $this->incoming->on('close', function () {
             $this->connectionOpen = false;
         });
-        if($this->maxExecutionTime > 0) {
+        if ($this->maxExecutionTime > 0) {
             $this->maxExecutionTimer = $this->loop->addTimer($this->maxExecutionTime, [$this, 'maxExecutionTimeExceeded']);
         }
 
@@ -291,7 +291,7 @@ class RequestHandler
             $this->incoming->write($this->createErrorResponse('502 Bad Gateway', 'Slave returned an invalid HTTP response. Maybe the script has called exit() prematurely?'));
         }
         $this->incoming->end();
-        if($this->maxExecutionTime > 0) {
+        if ($this->maxExecutionTime > 0) {
             $this->loop->cancelTimer($this->maxExecutionTimer);
         }
 


### PR DESCRIPTION
This adds a max-execution-time parameter that limits how long a script can run inside a worker before shutting it down. This should help with both https://github.com/php-pm/php-pm/issues/412 and https://github.com/php-pm/php-pm/issues/406 (still not a complete fix but will improve the situation further).