### PR TITLE
Fixes memory leak in case of cancelled http requests from the client

### DIFF
--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -76,6 +76,7 @@ class RequestHandler
 
     private $connectionOpen = true;
     private $redirectionTries = 0;
+    private $maxRedirectionTries = 3;
     private $incomingBuffer = '';
     private $lastOutgoingData = ''; // Used to track abnormal responses
 
@@ -149,7 +150,7 @@ class RequestHandler
             $slave = array_shift($available);
 
             // slave available -> connect
-            if (!$this->tryOccupySlave($slave)) {
+            if (!$this->tryOccupySlave($slave) && !$this->redirectionTries > $this->maxRedirectionTries) {
                 return $this->getNextSlave();
             }
         } else {


### PR DESCRIPTION
I've experienced a memory leak, where PPM allocs more and more memory because of a recursive call, until the server is OOM (and the process crashes).
This happens when the client cancels the HTTP request, before a response has been made.
The following "close handler" are then invoked
```        
$this->incoming->on('close', function () {
    $this->connectionOpen = false;
});
``` 

The result of this is `getNextSlave` recursively calls it self indefinitely because `tryOccupySlave($slave)` returns false.

```
public function getNextSlave()
{
    $available = $this->slaves->getByStatus(Slave::READY);

    if (count($available)) {
        // pick first slave
        $slave = array_shift($available);

        // slave available -> connect
        if (!$this->tryOccupySlave($slave)) {
            return $this->getNextSlave();
        }
...
```

```
public function tryOccupySlave(Slave $slave)
{
...
    $this->redirectionTries++;

    // client went away while waiting for worker
    if (!$this->connectionOpen) {
        return false;
    }
...
```

I'm not sure whenever this is the proper fix, but it mitigates the problem.