### PR TITLE
Implement memory-limit parameter

### DIFF
--- a/src/Commands/ConfigTrait.php
+++ b/src/Commands/ConfigTrait.php
@@ -26,6 +26,7 @@ trait ConfigTrait
             ->addOption('static-directory', null, InputOption::VALUE_REQUIRED, 'Static files root directory, if not provided static files will not be served', '')
             ->addOption('max-requests', null, InputOption::VALUE_REQUIRED, 'Max requests per worker until it will be restarted', 1000)
             ->addOption('max-execution-time', null, InputOption::VALUE_REQUIRED, 'Maximum amount of time a request is allowed to execute before shutting down', 30)
+            ->addOption('memory-limit', null, InputOption::VALUE_REQUIRED, 'Maximum amount of memory a worker is allowed to consume (in MB) before shutting down', 128)
             ->addOption('ttl', null, InputOption::VALUE_REQUIRED, 'Time to live for a worker until it will be restarted', null)
             ->addOption('populate-server-var', null, InputOption::VALUE_REQUIRED, 'If a worker application uses $_SERVER var it needs to be populated by request data 1|0', 1)
             ->addOption('bootstrap', null, InputOption::VALUE_REQUIRED, 'Class responsible for bootstrapping the application', 'PHPPM\Bootstraps\Symfony')
@@ -98,6 +99,7 @@ trait ConfigTrait
         $config['bootstrap'] = $this->optionOrConfigValue($input, 'bootstrap', $config);
         $config['max-requests'] = (int)$this->optionOrConfigValue($input, 'max-requests', $config);
         $config['max-execution-time'] = (int)$this->optionOrConfigValue($input, 'max-execution-time', $config);
+        $config['memory-limit'] = (int)$this->optionOrConfigValue($input, 'memory-limit', $config);
         $config['ttl'] = (int)$this->optionOrConfigValue($input, 'ttl', $config);
         $config['populate-server-var'] = (boolean)$this->optionOrConfigValue($input, 'populate-server-var', $config);
         $config['socket-path'] = $this->optionOrConfigValue($input, 'socket-path', $config);

--- a/src/Commands/ConfigTrait.php
+++ b/src/Commands/ConfigTrait.php
@@ -26,7 +26,7 @@ trait ConfigTrait
             ->addOption('static-directory', null, InputOption::VALUE_REQUIRED, 'Static files root directory, if not provided static files will not be served', '')
             ->addOption('max-requests', null, InputOption::VALUE_REQUIRED, 'Max requests per worker until it will be restarted', 1000)
             ->addOption('max-execution-time', null, InputOption::VALUE_REQUIRED, 'Maximum amount of time a request is allowed to execute before shutting down', 30)
-            ->addOption('memory-limit', null, InputOption::VALUE_REQUIRED, 'Maximum amount of memory a worker is allowed to consume (in MB) before shutting down', 256)
+            ->addOption('memory-limit', null, InputOption::VALUE_REQUIRED, 'Maximum amount of memory a worker is allowed to consume (in MB) before shutting down', -1)
             ->addOption('ttl', null, InputOption::VALUE_REQUIRED, 'Time to live for a worker until it will be restarted', null)
             ->addOption('populate-server-var', null, InputOption::VALUE_REQUIRED, 'If a worker application uses $_SERVER var it needs to be populated by request data 1|0', 1)
             ->addOption('bootstrap', null, InputOption::VALUE_REQUIRED, 'Class responsible for bootstrapping the application', 'PHPPM\Bootstraps\Symfony')

--- a/src/Commands/ConfigTrait.php
+++ b/src/Commands/ConfigTrait.php
@@ -26,7 +26,7 @@ trait ConfigTrait
             ->addOption('static-directory', null, InputOption::VALUE_REQUIRED, 'Static files root directory, if not provided static files will not be served', '')
             ->addOption('max-requests', null, InputOption::VALUE_REQUIRED, 'Max requests per worker until it will be restarted', 1000)
             ->addOption('max-execution-time', null, InputOption::VALUE_REQUIRED, 'Maximum amount of time a request is allowed to execute before shutting down', 30)
-            ->addOption('memory-limit', null, InputOption::VALUE_REQUIRED, 'Maximum amount of memory a worker is allowed to consume (in MB) before shutting down', 128)
+            ->addOption('memory-limit', null, InputOption::VALUE_REQUIRED, 'Maximum amount of memory a worker is allowed to consume (in MB) before shutting down', 256)
             ->addOption('ttl', null, InputOption::VALUE_REQUIRED, 'Time to live for a worker until it will be restarted', null)
             ->addOption('populate-server-var', null, InputOption::VALUE_REQUIRED, 'If a worker application uses $_SERVER var it needs to be populated by request data 1|0', 1)
             ->addOption('bootstrap', null, InputOption::VALUE_REQUIRED, 'Class responsible for bootstrapping the application', 'PHPPM\Bootstraps\Symfony')

--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -42,6 +42,7 @@ class StartCommand extends Command
         $handler->setAppBootstrap($config['bootstrap']);
         $handler->setMaxRequests($config['max-requests']);
         $handler->setMaxExecutionTime($config['max-execution-time']);
+        $handler->setMemoryLimit($config['memory-limit']);
         $handler->setTtl($config['ttl']);
         $handler->setPhpCgiExecutable($config['cgi-path']);
         $handler->setSocketPath($config['socket-path']);

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -75,7 +75,7 @@ class ProcessManager
      *
      * @var int
      */
-    protected $memoryLimit = 256;
+    protected $memoryLimit = -1;
 
     /**
      * Worker time to live
@@ -844,6 +844,15 @@ class ProcessManager
         try {
             $slave = $this->slaves->getByConnection($conn);
             $slave->setUsedMemory($data['memory_usage']);
+            if ($this->output->isVeryVerbose()) {
+                $this->output->writeln(
+                    sprintf(
+                        'Current memory usage for worker %d: %.2f MB',
+                        $slave->getPort(),
+                        $data['memory_usage']
+                    )
+                );
+            }
         } catch (\Exception $e) {
             // silent
         }

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -71,6 +71,13 @@ class ProcessManager
     protected $maxExecutionTime = 30;
 
     /**
+     * Maximum amount of memory a worker is allowed to consume before shutting down
+     *
+     * @var int
+     */
+    protected $memoryLimit = 256;
+
+    /**
      * Worker time to live
      *
      * @var int|null
@@ -330,6 +337,22 @@ class ProcessManager
     public function setMaxExecutionTime($maxExecutionTime)
     {
         $this->maxExecutionTime = $maxExecutionTime;
+    }
+
+    /**
+     * @return int
+     */
+    public function getMemoryLimit()
+    {
+        return $this->memoryLimit;
+    }
+
+    /**
+     * @param int $memoryLimit
+     */
+    public function setMemoryLimit($memoryLimit)
+    {
+        $this->memoryLimit = $memoryLimit;
     }
 
     /**
@@ -1134,6 +1157,7 @@ class ProcessManager
             'app-env' => $this->getAppEnv(),
             'debug' => $this->isDebug(),
             'logging' => $this->isLogging(),
+            'memory-limit' => $this->getMemoryLimit(),
             'static-directory' => $this->getStaticDirectory(),
             'populate-server-var' => $this->isPopulateServer()
         ];

--- a/src/ProcessSlave.php
+++ b/src/ProcessSlave.php
@@ -450,15 +450,17 @@ class ProcessSlave
             $this->shutdown();
         }
         // Enforce memory limit
-        $this->loop->futureTick(function() {
-            $usedMemory = round(memory_get_usage(true)/1048576,2); // Convert to MB
-            if($usedMemory >= $this->getMemoryLimit()) {
-                error_log(
-                    sprintf('Restart worker because it reached memory limit of %d', $this->getMemoryLimit())
-                );
-                $this->shutdown();
-            }
-        });
+        if($this->getMemoryLimit() > 0) {
+            $this->loop->futureTick(function() {
+                $usedMemory = round(memory_get_usage(true)/1048576,2); // Convert to MB
+                if($usedMemory >= $this->getMemoryLimit()) {
+                    error_log(
+                        sprintf('Restart worker because it reached memory limit of %d', $this->getMemoryLimit())
+                    );
+                    $this->shutdown();
+                }
+            });
+        }
         return $response;
     }
 

--- a/src/ProcessSlave.php
+++ b/src/ProcessSlave.php
@@ -147,6 +147,14 @@ class ProcessSlave
     }
 
     /**
+     * @return int
+     */
+    public function getMemoryLimit()
+    {
+        return $this->config['memory-limit'];
+    }
+
+    /**
      * Shuts down the event loop. This basically exits the process.
      */
     public function shutdown()
@@ -441,6 +449,16 @@ class ProcessSlave
             );
             $this->shutdown();
         }
+        // Enforce memory limit
+        $this->loop->futureTick(function() {
+            $usedMemory = round(memory_get_usage(true)/1048576,2); // Convert to MB
+            if($usedMemory >= $this->getMemoryLimit()) {
+                error_log(
+                    sprintf('Restart worker because it reached memory limit of %d', $this->getMemoryLimit())
+                );
+                $this->shutdown();
+            }
+        });
         return $response;
     }
 

--- a/src/ProcessSlave.php
+++ b/src/ProcessSlave.php
@@ -147,14 +147,6 @@ class ProcessSlave
     }
 
     /**
-     * @return int
-     */
-    public function getMemoryLimit()
-    {
-        return $this->config['memory-limit'];
-    }
-
-    /**
      * Shuts down the event loop. This basically exits the process.
      */
     public function shutdown()
@@ -449,18 +441,7 @@ class ProcessSlave
             );
             $this->shutdown();
         }
-        // Enforce memory limit
-        if ($this->getMemoryLimit() > 0) {
-            $this->loop->futureTick(function () {
-                $usedMemory = round(memory_get_usage(true)/1048576, 2); // Convert to MB
-                if ($usedMemory >= $this->getMemoryLimit()) {
-                    error_log(
-                        sprintf('Restart worker because it reached memory limit of %d', $this->getMemoryLimit())
-                    );
-                    $this->shutdown();
-                }
-            });
-        }
+        $this->sendMessage($this->controller, 'stats', ['memory_usage' => round(memory_get_usage(true)/1048576, 2)]);
         return $response;
     }
 

--- a/src/ProcessSlave.php
+++ b/src/ProcessSlave.php
@@ -441,7 +441,7 @@ class ProcessSlave
             );
             $this->shutdown();
         }
-        $this->sendMessage($this->controller, 'stats', ['memory_usage' => round(memory_get_usage(true)/1048576, 2)]);
+        $this->sendMessage($this->controller, 'stats', ['memory_usage' => round(memory_get_peak_usage(true)/1048576, 2)]); // Convert memory usage to MB
         return $response;
     }
 

--- a/src/ProcessSlave.php
+++ b/src/ProcessSlave.php
@@ -450,10 +450,10 @@ class ProcessSlave
             $this->shutdown();
         }
         // Enforce memory limit
-        if($this->getMemoryLimit() > 0) {
-            $this->loop->futureTick(function() {
-                $usedMemory = round(memory_get_usage(true)/1048576,2); // Convert to MB
-                if($usedMemory >= $this->getMemoryLimit()) {
+        if ($this->getMemoryLimit() > 0) {
+            $this->loop->futureTick(function () {
+                $usedMemory = round(memory_get_usage(true)/1048576, 2); // Convert to MB
+                if ($usedMemory >= $this->getMemoryLimit()) {
                     error_log(
                         sprintf('Restart worker because it reached memory limit of %d', $this->getMemoryLimit())
                     );

--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -314,6 +314,13 @@ class RequestHandler
                 $this->output->writeln(sprintf('Restart worker #%d because it reached max requests of %d', $this->slave->getPort(), $maxRequests));
                 $connection->close();
             }
+            // Enforce memory limit
+            $memoryLimit = $this->slave->getMemoryLimit();
+            if ($this->slave->getUsedMemory() >= $memoryLimit) {
+                $this->slave->close();
+                $this->output->writeln(sprintf('Restart worker #%d because it reached memory limit of %d', $this->slave->getPort(), $memoryLimit));
+                $connection->close();
+            }
         }
     }
 

--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -316,7 +316,7 @@ class RequestHandler
             }
             // Enforce memory limit
             $memoryLimit = $this->slave->getMemoryLimit();
-            if ($this->slave->getUsedMemory() >= $memoryLimit) {
+            if ($memoryLimit > 0 && $this->slave->getUsedMemory() >= $memoryLimit) {
                 $this->slave->close();
                 $this->output->writeln(sprintf('Restart worker #%d because it reached memory limit of %d', $this->slave->getPort(), $memoryLimit));
                 $connection->close();

--- a/src/Slave.php
+++ b/src/Slave.php
@@ -56,11 +56,25 @@ class Slave
     private $maxRequests = 0;
 
     /**
+     * Maximum amount of memory the slave can consume
+     *
+     * @var int
+     */
+    private $memoryLimit = 256;
+
+    /**
      * Number of handled requests
      *
      * @var int
      */
     private $handledRequests = 0;
+
+    /**
+     * Amount of memory last consumed by the worker
+     *
+     * @var int
+     */
+    private $usedMemory = 0;
 
     /**
      * Time to live
@@ -76,10 +90,11 @@ class Slave
      */
     private $startedAt;
 
-    public function __construct($port, $maxRequests, $ttl = null)
+    public function __construct($port, $maxRequests, $memoryLimit, $ttl = null)
     {
         $this->port = $port;
         $this->maxRequests = $maxRequests;
+        $this->memoryLimit = $memoryLimit;
         $this->ttl = ((int) $ttl < 1) ? null : $ttl;
         $this->startedAt = time();
 
@@ -250,6 +265,24 @@ class Slave
     }
 
     /**
+     * Get the amount of memory the worker is currently consuming
+     *
+     * @return int amount of memory in MB
+     */
+    public function getUsedMemory()
+    {
+        return $this->usedMemory;
+    }
+
+    /**
+     * @param int $usedMemory
+     */
+    public function setUsedMemory($usedMemory)
+    {
+        $this->usedMemory = $usedMemory;
+    }
+
+    /**
      * Get maximum number of request slave can handle
      *
      * @return int handled requests
@@ -257,6 +290,16 @@ class Slave
     public function getMaxRequests()
     {
         return $this->maxRequests;
+    }
+
+    /**
+     * Get maximum amount of memory the slave can consume
+     *
+     * @return int amount of memory in MB
+     */
+    public function getMemoryLimit()
+    {
+        return $this->memoryLimit;
     }
 
     /**

--- a/src/Slave.php
+++ b/src/Slave.php
@@ -60,7 +60,7 @@ class Slave
      *
      * @var int
      */
-    private $memoryLimit = 256;
+    private $memoryLimit = -1;
 
     /**
      * Number of handled requests


### PR DESCRIPTION
This PR implements a memory-limit parameter that restarts the worker if exceeded.
This allows handling memory leaks based on the actual effect and is useful when running PPM in environments with limited memory.