### PR TITLE
fix server shutdown when all worker are crashed

### DIFF
--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -256,7 +256,7 @@ class ProcessManager
         $this->output->writeln("<info>Server is shutting down.</info>");
         $this->status = self::STATE_SHUTDOWN;
 
-        $remainingSlaves = $this->slaveCount;
+        $remainingSlaves = count($this->slaves->getByStatus(Slave::READY));
 
         if ($remainingSlaves === 0) {
             // if for some reason there are no workers, the close callback won't do anything, so just quit.


### PR DESCRIPTION
I observed that php pm master process stay alive whereas all workers are crashed and stuck in shutdown. This PR fix it, if 0 worker ready, it directly quit