### PR TITLE
Exit worker more cleanly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ script:
   - bash -c 'if [[ $(curl --write-out %{http_code} --silent --output /dev/null "http://127.0.0.1:8080/test?exception=1") == "502" ]]; then exit 0; else exit 1; fi'
   - bash -c 'grep -q "An exception was thrown by the bridge. Forcing restart of the worker. The exception was" /tmp/ppmout && exit 0'
   - bash -c 'grep -q "This is a very bad exception" /tmp/ppmout && exit 0'
+  - bash -c 'grep -q "Shutdown function triggered" /tmp/ppmoutshutdownfunc && exit 0'
   - bin/ppm status
   - bin/ppm stop
 

--- a/src/ProcessSlave.php
+++ b/src/ProcessSlave.php
@@ -196,11 +196,9 @@ class ProcessSlave
             @$this->server->close();
         }
 
-        if (!$this->loop) {
-            return;
+        if ($this->loop) {
+            $this->loop->stop();
         }
-
-        $this->loop->stop();
     }
 
     /**

--- a/src/ProcessSlave.php
+++ b/src/ProcessSlave.php
@@ -187,6 +187,8 @@ class ProcessSlave
 
         $this->inShutdown = true;
 
+        $this->sendCurrentFiles();
+
         if ($this->controller && $this->controller->isWritable()) {
             $this->controller->close();
         }
@@ -198,7 +200,6 @@ class ProcessSlave
             return;
         }
 
-        $this->sendCurrentFiles();
         $this->loop->stop();
     }
 

--- a/tests/TestBridge.php
+++ b/tests/TestBridge.php
@@ -25,6 +25,9 @@ class TestBridge extends StaticBridge
             $longvar =  str_repeat('Lorem Ipsum', $params['memory']*1048576); // Create a multi-megabyte string
         }
         if(isset($params['exception'])) {
+            register_shutdown_function(function() {
+                file_put_contents('/tmp/ppmoutshutdownfunc', 'Shutdown function triggered');
+            });
             throw new \Exception('This is a very bad exception');
         }
         return new Psr7\Response(404, ['Content-type' => 'text/plain'], 'Not found');


### PR DESCRIPTION
Currently when `ProcessSlave` exits, the application's registered shutdown functions sometimes do not execute because our `shutdown` calls `exit` internally (when a registered shutdown function calls `exit`, the others do not execute, as mentioned in the [documentation](http://php.net/manual/en/function.register-shutdown-function.php)).

This PR makes the worker exit more cleanly, by not calling `exit` inside the worker's `shutdown` function, but outside of it.