### PR TITLE
Add "X-PPM-Restart" Header where the application can force a restart …

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,3 +178,7 @@ framework:
 ```
 
 More information at http://symfony.com/doc/current/cookbook/request/load_balancer_reverse_proxy.html.
+
+### Programmatically restarting Worker
+
+We provide the `X-PPM-Restart` HTTP Header to restart the current worker with content `worker` or `all`. You can send this header in the response from your application.

--- a/src/SlavePool.php
+++ b/src/SlavePool.php
@@ -120,4 +120,14 @@ class SlavePool
             return count($this->getByStatus($state));
         }, $map);
     }
+
+    /**
+     * Returns all slaves in pool
+     *
+     * @return Slave[]
+     */
+    public function getSlaves()
+    {
+        return $this->slaves;
+    }
 }


### PR DESCRIPTION
Like described in #437 i need something to restart programmatically a worker or all.

With this addition a Application can send in response header "X-PPM-Restart: worker" to restart the current worker which handled the response or "X-PPM-Restart: all" to restart all workers.

Why we need that? If a application has dynamic proxies and they change in the runtime, the application could send this header to restart the worker to load the new proxy.

I used strpos to find the header, if someone else have a better performant idea to read a header :)