### PR TITLE
Don't start slave when reload app

### DIFF
--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -608,7 +608,7 @@ class ProcessManager
          */
         if ($status === Slave::REGISTERED) {
             $this->bootstrapFailed($port);
-        } else {
+        } elseif ($status !== Slave::CLOSED) {
             // recreate
             $this->newSlaveInstance($port);
         }


### PR DESCRIPTION
This fixed: 

Test `ab -c 10 -n 500 "http://localhost:8080/abtesting/" & bash -c "sleep 5; ./vendor/bin/ppm reload --cgi-path=/usr/local/bin/php"`

Without the fix, I see errors in stderr ppm:
```
Current memory usage for worker 5505: 14.00 MB
[27/Aug/2019:10:05:25 +0300] 172.17.0.1 - - "GET /abtesting HTTP/1.0" 200 18323 "-"
Worker 5505 took abnormal 2.632 seconds for handling a connection
Marking locked worker #5505 as closed
Worker #5505 closed after 0 handled requests
Start new worker #5505
Worker #5505 has been closed, reloading.
Start new worker #5505

In SlavePool.php line 29:

  [Exception]
  Slave port 5505 already occupied.


Exception trace:
  at /var/www/html/vendor/php-pm/php-pm/src/SlavePool.php:29
 PHPPM\SlavePool->add() at /var/www/html/vendor/php-pm/php-pm/src/ProcessManager.php:1238
 PHPPM\ProcessManager->newSlaveInstance() at /var/www/html/vendor/php-pm/php-pm/src/ProcessManager.php:1024
 PHPPM\ProcessManager->PHPPM\{closure}() at /var/www/html/vendor/php-pm/php-pm/src/ProcessManager.php:1068
 PHPPM\ProcessManager->PHPPM\{closure}() at /var/www/html/vendor/evenement/evenement/src/Evenement/EventEmitterTrait.php:123
 Evenement\EventEmitter->emit() at /var/www/html/vendor/react/stream/src/Util.php:71
 React\Stream\Util::React\Stream\{closure}() at /var/www/html/vendor/evenement/evenement/src/Evenement/EventEmitterTrait.php:123
 Evenement\EventEmitter->emit() at /var/www/html/vendor/react/stream/src/DuplexResourceStream.php:138
 React\Stream\DuplexResourceStream->close() at /var/www/html/vendor/react/socket/src/Connection.php:118
 React\Socket\Connection->close() at /var/www/html/vendor/php-pm/php-pm/src/RequestHandler.php:301
 PHPPM\RequestHandler->slaveClosed() at /var/www/html/vendor/evenement/evenement/src/Evenement/EventEmitterTrait.php:123
 Evenement\EventEmitter->emit() at /var/www/html/vendor/react/stream/src/Util.php:71
 React\Stream\Util::React\Stream\{closure}() at /var/www/html/vendor/evenement/evenement/src/Evenement/EventEmitterTrait.php:123
 Evenement\EventEmitter->emit() at /var/www/html/vendor/react/stream/src/DuplexResourceStream.php:138
 React\Stream\DuplexResourceStream->close() at /var/www/html/vendor/react/stream/src/DuplexResourceStream.php:197
 React\Stream\DuplexResourceStream->handleData() at /var/www/html/vendor/react/event-loop/src/StreamSelectLoop.php:244
 React\EventLoop\StreamSelectLoop->waitForStreamActivity() at /var/www/html/vendor/react/event-loop/src/StreamSelectLoop.php:211
 React\EventLoop\StreamSelectLoop->run() at /var/www/html/vendor/php-pm/php-pm/src/ProcessManager.php:521
 PHPPM\ProcessManager->run() at /var/www/html/vendor/php-pm/php-pm/src/Commands/StartCommand.php:52
 PHPPM\Commands\StartCommand->execute() at /var/www/html/vendor/symfony/console/Command/Command.php:255
 Symfony\Component\Console\Command\Command->run() at /var/www/html/vendor/symfony/console/Application.php:915
 Symfony\Component\Console\Application->doRunCommand() at /var/www/html/vendor/symfony/console/Application.php:272
 Symfony\Component\Console\Application->doRun() at /var/www/html/vendor/symfony/console/Application.php:148
 Symfony\Component\Console\Application->run() at /var/www/html/vendor/php-pm/php-pm/bin/ppm:47

start [--bridge BRIDGE] [--host HOST] [--port PORT] [--workers WORKERS] [--app-env APP-ENV] [--debug DEBUG] [--logging LOGGING] [--static-directory STATIC-DIRECTORY] [--max-requests MAX-REQUESTS] [--max-execution-time MAX-EXECUTION-TIME] [--memory-limit MEMORY-LIMIT] [--ttl TTL] [--populate-server-var POPULATE-SERVER-VAR] [--bootstrap BOOTSTRAP] [--cgi-path CGI-PATH] [--socket-path SOCKET-PATH] [--pidfile PIDFILE] [--reload-timeout RELOAD-TIMEOUT] [-c|--config CONFIG] [--] [<working-directory>]

Server is shutting down.
Stopping the process manager.
2019-08-27 07:05:28,563 INFO exited: php-ppm (exit status 1; not expected)
2019-08-27 07:05:28,576 INFO spawned: 'php-ppm' with pid 179
/var/www/html
+---------------------+-------------------------------+
| bridge              | \RMS\RestApi\PhpPM\SlimBridge |
| host                | 0.0.0.0                       |
| port                | 8080                          |
| workers             | 8                             |
| app-env             | prod                          |
| debug               | 0                             |
| logging             | 1                             |
| static-directory    |                               |
| bootstrap           | \RMS\RestApi\PhpPM\Bootstrap  |
| max-requests        | 1000                          |
| max-execution-time  | 30                            |
| memory-limit        | 192                           |
| ttl                 | 0                             |
| populate-server-var | 1                             |
| socket-path         | .ppm/run/                     |
| pidfile             | .ppm/ppm.pid                  |
| reload-timeout      | 30                            |
| cgi-path            | /usr/local/bin/php            |
+---------------------+-------------------------------+

In TcpServer.php line 164:

  [RuntimeException]
  Failed to listen on "tcp://0.0.0.0:8080": Address in use


Exception trace:
  at /var/www/html/vendor/react/socket/src/TcpServer.php:164
 React\Socket\TcpServer->__construct() at /var/www/html/vendor/react/socket/src/Server.php:36
 React\Socket\Server->__construct() at /var/www/html/vendor/php-pm/php-pm/src/ProcessManager.php:499
 PHPPM\ProcessManager->run() at /var/www/html/vendor/php-pm/php-pm/src/Commands/StartCommand.php:52
 PHPPM\Commands\StartCommand->execute() at /var/www/html/vendor/symfony/console/Command/Command.php:255
 Symfony\Component\Console\Command\Command->run() at /var/www/html/vendor/symfony/console/Application.php:915
 Symfony\Component\Console\Application->doRunCommand() at /var/www/html/vendor/symfony/console/Application.php:272
 Symfony\Component\Console\Application->doRun() at /var/www/html/vendor/symfony/console/Application.php:148
 Symfony\Component\Console\Application->run() at /var/www/html/vendor/php-pm/php-pm/bin/ppm:47

start [--bridge BRIDGE] [--host HOST] [--port PORT] [--workers WORKERS] [--app-env APP-ENV] [--debug DEBUG] [--logging LOGGING] [--static-directory STATIC-DIRECTORY] [--max-requests MAX-REQUESTS] [--max-execution-time MAX-EXECUTION-TIME] [--memory-limit MEMORY-LIMIT] [--ttl TTL] [--populate-server-var POPULATE-SERVER-VAR] [--bootstrap BOOTSTRAP] [--cgi-path CGI-PATH] [--socket-path SOCKET-PATH] [--pidfile PIDFILE] [--reload-timeout RELOAD-TIMEOUT] [-c|--config CONFIG] [--] [<working-directory>]

Server is shutting down.
Stopping the process manager.
PHP Fatal error:  Uncaught ErrorException: Warning: unlink(.ppm/ppm.pid): No such file or directory in /var/www/html/vendor/php-pm/php-pm/src/ProcessManager.php:306
Stack trace:
#0 /var/www/html/vendor/php-pm/php-pm/src/ProcessManager.php(263): PHPPM\ProcessManager->quit()
#1 [internal function]: PHPPM\ProcessManager->shutdown()
#2 {main}
  thrown in /var/www/html/vendor/php-pm/php-pm/src/ProcessManager.php on line 306
PHP Stack trace:
PHP   1. {main}() /var/www/html/vendor/php-pm/php-pm/bin/ppm:0
PHP   2. Symfony\Component\Console\Application->run() /var/www/html/vendor/php-pm/php-pm/bin/ppm:47
2019-08-27 07:05:29,450 INFO exited: php-ppm (exit status 1; not expected)
^C2019-08-27 07:05:29,786 WARN received SIGINT indicating exit request
2019-08-27 07:05:29,786 INFO waiting for processes, php-ppm, statsd_exporter, confd to die
2019-08-27 07:05:29,788 INFO stopped: statsd_exporter (terminated by SIGTERM)
2019-08-27T07:05:29Z 00ab0492ec00 /usr/local/sbin/confd[89]: INFO Captured terminated. Exiting...
2019-08-27 07:05:29,794 INFO stopped: confd (exit status 0)
^C2019-08-27 07:05:30,712 WARN received SIGINT indicating exit request
2019-08-27 07:05:30,714 INFO stopped: processes (terminated by SIGTERM)
```
