### PR TITLE
Fix a small memory leak with the RequestHandler

### DIFF
--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -65,7 +65,7 @@ class RequestHandler
     /**
      * Timer that handles stopping the worker if script has excceed the max execution time
      *
-     * @var TimerInterface
+     * @var TimerInterface|null
      */
     private $maxExecutionTimer;
 
@@ -292,6 +292,8 @@ class RequestHandler
         $this->incoming->end();
         if ($this->maxExecutionTime > 0) {
             $this->loop->cancelTimer($this->maxExecutionTimer);
+            //Explicitly null the property to avoid a cyclic memory reference
+            $this->maxExecutionTimer = null;
         }
 
         if ($this->slave->getStatus() === Slave::LOCKED) {


### PR DESCRIPTION
As discussed in #461 , a smaller memory leak remained on php-pm. The culprit is the `maxExecutionTimer` inside the `RequestHandler`. What happens is that a cyclic memory reference is created between the `RequestHandler` and the `maxExecutionTimer`. Therefore, when the request ends, the `RequestHandler` cannot be cleaned up, because it has a property inside that points to itself. What we do on this PR is manually breaking the cycle by nulling the property when it's no longer useful.

The GC eventually cleans it up, but we're unnecessary filling up the memory roots buffer and kicking in the GC (which takes a bit of time). I found out the GC kicks in after 1200 requests or so. Thanks to PHP 7.3 we now have a new `gc_status` function that will tell you hay many times the GC has kicked in and the size of the roots buffer.

At request n1:
```
Before => memory: 3369792B, num roots: 288, gc_runs: 0
After  => memory: 3369792B, num roots: 288, gc_runs: 0
``` 
At request n1000
```
Before => memory: 5930984B, num roots: 9279, gc_runs: 0
After  => memory: 3369824B, num roots:  288, gc_runs: 0
```
At request n2000
```
Before => memory: 5826896B, num roots: 8344, gc_runs: 1
After  => memory: 3369824B, num roots:  288, gc_runs: 0
```