### PR TITLE
Periodically send refresh signal to Application

### DIFF
--- a/src/Bridges/RefreshableBridgeInterface.php
+++ b/src/Bridges/RefreshableBridgeInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace PHPPM\Bridges;
+
+interface RefreshableBridgeInterface
+{
+    public function refreshApplication();
+}

--- a/src/Commands/ConfigTrait.php
+++ b/src/Commands/ConfigTrait.php
@@ -34,6 +34,7 @@ trait ConfigTrait
             ->addOption('socket-path', null, InputOption::VALUE_REQUIRED, 'Path to a folder where socket files will be placed. Relative to working-directory or cwd()', '.ppm/run/')
             ->addOption('pidfile', null, InputOption::VALUE_REQUIRED, 'Path to a file where the pid of the master process is going to be stored', '.ppm/ppm.pid')
             ->addOption('reload-timeout', null, InputOption::VALUE_REQUIRED, 'The number of seconds to wait before force closing a worker during a reload, or -1 to disable. Default: 30', 30)
+            ->addOption('refresh-interval', null, InputOption::VALUE_REQUIRED, 'Seconds after workers will periodically be sent a refresh signal. Default: 0 = off', 0)
             ->addOption('config', 'c', InputOption::VALUE_REQUIRED, 'Path to config file', '');
     }
 
@@ -105,6 +106,7 @@ trait ConfigTrait
         $config['socket-path'] = $this->optionOrConfigValue($input, 'socket-path', $config);
         $config['pidfile'] = $this->optionOrConfigValue($input, 'pidfile', $config);
         $config['reload-timeout'] = $this->optionOrConfigValue($input, 'reload-timeout', $config);
+        $config['refresh-interval'] = $this->optionOrConfigValue($input, 'refresh-interval', $config);
 
         $config['cgi-path'] = $this->optionOrConfigValue($input, 'cgi-path', $config);
 

--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -49,6 +49,7 @@ class StartCommand extends Command
         $handler->setPIDFile($config['pidfile']);
         $handler->setPopulateServer($config['populate-server-var']);
         $handler->setStaticDirectory($config['static-directory']);
+        $handler->setRefreshInterval($config['refresh-interval']);
         $handler->run();
 
         return null;

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -556,7 +556,9 @@ class ProcessManager
     {
         $slave = $this->slaves->getByConnection($connection);
         $slave->releaseFromRefresh();
-        $this->output->writeln(sprintf('worker #%d refreshed', $slave->getPort()));
+        if ($this->output->isVerbose()) {
+            $this->output->writeln(sprintf('worker #%d refreshed', $slave->getPort()));
+        }
     }
 
     /**

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -541,7 +541,6 @@ class ProcessManager
     public function refreshSlaves()
     {
         $slaves = $this->slaves->findSlavesToBeRefreshed($this->refreshInterval);
-        $this->output->writeln(sprintf('refreshing %d workers', count($slaves)));
 
         foreach ($slaves as $slave) {
             $slave->markForRefresh();

--- a/src/ProcessSlave.php
+++ b/src/ProcessSlave.php
@@ -373,7 +373,7 @@ class ProcessSlave
 
     protected function doRefresh()
     {
-        if ( ! ($bridge = $this->getBridge()) || ! ($bridge instanceof RefreshableBridgeInterface)) {
+        if (! ($bridge = $this->getBridge()) || ! ($bridge instanceof RefreshableBridgeInterface)) {
             return;
         }
 

--- a/src/ProcessSlave.php
+++ b/src/ProcessSlave.php
@@ -5,6 +5,7 @@ namespace PHPPM;
 
 use Evenement\EventEmitterInterface;
 use PHPPM\Bridges\BridgeInterface;
+use PHPPM\Bridges\RefreshableBridgeInterface;
 use PHPPM\Debug\BufferingLogger;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -253,6 +254,7 @@ class ProcessSlave
     {
         if ($bridge = $this->getBridge()) {
             $bridge->bootstrap($appBootstrap, $appenv, $debug);
+            $this->doRefresh();
             $this->sendMessage($this->controller, 'ready');
         }
     }
@@ -361,6 +363,21 @@ class ProcessSlave
         $this->bootstrap($this->appBootstrap, $this->config['app-env'], $this->isDebug());
 
         $this->sendCurrentFiles();
+    }
+
+    public function commandRefresh()
+    {
+        $this->doRefresh();
+        $this->sendMessage($this->controller, 'refreshed');
+    }
+
+    protected function doRefresh()
+    {
+        if ( ! ($bridge = $this->getBridge()) || ! ($bridge instanceof RefreshableBridgeInterface)) {
+            return;
+        }
+
+        $bridge->refreshApplication();
     }
 
     /**

--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -212,8 +212,7 @@ class RequestHandler
         // mark slave as busy
         $this->slave->occupy();
 
-        $connector = new UnixConnector($this->loop);
-        $connector = new TimeoutConnector($connector, $this->timeout, $this->loop);
+        $connector = new TimeoutConnector(new UnixConnector($this->loop), $this->timeout, $this->loop);
 
         $socketPath = $this->getSlaveSocketPath($this->slave->getPort());
         $connector->connect($socketPath)->then(

--- a/src/SlavePool.php
+++ b/src/SlavePool.php
@@ -101,7 +101,7 @@ class SlavePool
     }
 
     /**
-     * @param $refreshInterval
+     * @param int $refreshInterval
      * @return Slave[]
      */
     public function findSlavesToBeRefreshed($refreshInterval) : array


### PR DESCRIPTION
I primarily use PPM to have all kinds of data ready for computation at runtime when a request is coming in. In order for that data to be fresh, i need to reload periodically. 
Because `ttl` only reloads after a request, i cannot be sure that my data is fresh.

Also, with this feature the worker does not get killed but only the method `refreshApplication()` will be fired on the bridge every `refresh-interval` seconds. 

Note: Only ¼ of the workers in `ready` state and ready to refresh will be sent to refresh once every 5 seconds.
