### PR TITLE
Add TCP Context in the configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /vendor/
 /.vscode/
 /.ppm/
+composer.lock

--- a/src/Commands/ConfigTrait.php
+++ b/src/Commands/ConfigTrait.php
@@ -34,6 +34,7 @@ trait ConfigTrait
             ->addOption('socket-path', null, InputOption::VALUE_REQUIRED, 'Path to a folder where socket files will be placed. Relative to working-directory or cwd()', '.ppm/run/')
             ->addOption('pidfile', null, InputOption::VALUE_REQUIRED, 'Path to a file where the pid of the master process is going to be stored', '.ppm/ppm.pid')
             ->addOption('reload-timeout', null, InputOption::VALUE_REQUIRED, 'The number of seconds to wait before force closing a worker during a reload, or -1 to disable. Default: 30', 30)
+            ->addOption('tcp-context', null, InputOption::VALUE_REQUIRED, 'JSON encoded array of TCP context options (see https://reactphp.org/socket/#server). Default: []', '[]')
             ->addOption('config', 'c', InputOption::VALUE_REQUIRED, 'Path to config file', '');
     }
 
@@ -105,7 +106,7 @@ trait ConfigTrait
         $config['socket-path'] = $this->optionOrConfigValue($input, 'socket-path', $config);
         $config['pidfile'] = $this->optionOrConfigValue($input, 'pidfile', $config);
         $config['reload-timeout'] = $this->optionOrConfigValue($input, 'reload-timeout', $config);
-
+        $config['tcp-context'] = $this->optionOrConfigValue($input, 'tcp-context', $config);
         $config['cgi-path'] = $this->optionOrConfigValue($input, 'cgi-path', $config);
 
         if (false === $config['cgi-path']) {

--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -49,6 +49,7 @@ class StartCommand extends Command
         $handler->setPIDFile($config['pidfile']);
         $handler->setPopulateServer($config['populate-server-var']);
         $handler->setStaticDirectory($config['static-directory']);
+        $handler->setTcpContext(\json_decode($config['tcp-context'], true, 512, JSON_THROW_ON_ERROR));
         $handler->run();
 
         return null;

--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -49,7 +49,7 @@ class StartCommand extends Command
         $handler->setPIDFile($config['pidfile']);
         $handler->setPopulateServer($config['populate-server-var']);
         $handler->setStaticDirectory($config['static-directory']);
-        $handler->setTcpContext(\json_decode($config['tcp-context'], true, 512, JSON_THROW_ON_ERROR));
+        $handler->setTcpContext(\json_decode($config['tcp-context'], true, 512, \defined('JSON_THROW_ON_ERROR') ? JSON_THROW_ON_ERROR : JSON_PARTIAL_OUTPUT_ON_ERROR));
         $handler->run();
 
         return null;

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -223,6 +223,13 @@ class ProcessManager
     const CONTROLLER_PORT = 5500;
 
     /**
+     * TCP context options.
+     *
+     * @var array
+     */
+    protected $tcp_context = [];
+
+    /**
      * ProcessManager constructor.
      *
      * @param OutputInterface $output
@@ -303,7 +310,10 @@ class ProcessManager
             $this->loop->stop();
         }
 
-        unlink($this->pidfile);
+        if(file_exists($this->pidfile)) {
+            unlink($this->pidfile);
+        }
+        
         exit;
     }
 
@@ -480,6 +490,22 @@ class ProcessManager
     }
 
     /**
+     * @param array $tcp_context
+     */
+    public function setTcpContext(array $tcp_context)
+    {
+        $this->tcp_context = $tcp_context;
+    }
+
+    /**
+     * @return array
+     */
+    public function getTcpContext()
+    {
+        return $this->tcp_context;
+    }
+
+    /**
      * Starts the main loop. Blocks.
      */
     public function run()
@@ -496,7 +522,7 @@ class ProcessManager
         $this->controller = new UnixServer($this->getControllerSocketPath(), $this->loop);
         $this->controller->on('connection', [$this, 'onSlaveConnection']);
 
-        $this->web = new Server(sprintf('%s:%d', $this->host, $this->port), $this->loop);
+        $this->web = new Server(sprintf('%s:%d', $this->host, $this->port), $this->loop, $this->getTcpContext());
         $this->web->on('connection', [$this, 'onRequest']);
 
         $this->loop->addSignal(SIGTERM, [$this, 'shutdown']);

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -310,7 +310,7 @@ class ProcessManager
             $this->loop->stop();
         }
 
-        if(file_exists($this->pidfile)) {
+        if (file_exists($this->pidfile)) {
             unlink($this->pidfile);
         }
         

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -227,7 +227,7 @@ class ProcessManager
      *
      * @var array
      */
-    protected $tcp_context = [];
+    protected $tcpContext = [];
 
     /**
      * ProcessManager constructor.
@@ -490,11 +490,11 @@ class ProcessManager
     }
 
     /**
-     * @param array $tcp_context
+     * @param array $tcpContext
      */
-    public function setTcpContext(array $tcp_context)
+    public function setTcpContext(array $tcpContext)
     {
-        $this->tcp_context = $tcp_context;
+        $this->tcpContext = $tcpContext;
     }
 
     /**
@@ -502,7 +502,7 @@ class ProcessManager
      */
     public function getTcpContext()
     {
-        return $this->tcp_context;
+        return $this->tcpContext;
     }
 
     /**

--- a/tests/ProcessManagerTest.php
+++ b/tests/ProcessManagerTest.php
@@ -72,4 +72,26 @@ class ProcessManagerTest extends PhpPmTestCase
         $isHeaderEnd = $this->getRequestHandlerMethod('isHeaderEnd');
         $this->assertEquals($isHeaderEnd($header), $isEnd);
     }
+
+    public function testTcpContextOptions()
+    {
+        // Init Console Null output because we are in a test env.
+        $nullOutput = new \Symfony\Component\Console\Output\NullOutput();
+
+        // Build a ProcessManager Wrapper to access protected attributes.
+        $manager = new \PHPPM\ProcessManager($nullOutput);
+
+        // TLS Context to provide to the process manager
+        $tls_context = [
+            'local_cert' => 'local_cert.pem'
+        ];
+
+        // Assign TLS options in the TCP Context
+        $manager->setTcpContext([
+            'tls' => $tls_context
+        ]);
+
+        // Tests !
+        $this->assertEquals(['tls' => $tls_context], $manager->getTcpContext());
+    }
 }


### PR DESCRIPTION
Add the possibility to provide the TCP context in the start process of ProcessManager, and gives the opportunity to build Secure Socket. Related #462 

Usage : This PR add ```--tcp-context``` option which accept an JSON array encoded.

Example : ```php bin/ppm start --tcp-context '{"tls":{"local_cert": "test.pem"}}'```

This is the first shot.

What do you think ? 

Also, I have some difficulty to make the ConfigTrait testable, if you have some ideas, I will take them.