### PR TITLE
Do not export tests folder

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/tests export-ignore
+/.* export-ignore


### PR DESCRIPTION
It's nice to have a .gitattributes file so that the tests folder is not exported when packaging releases