### PR TITLE
Update react/http to v1.0.0

### DIFF
--- a/src/ProcessSlave.php
+++ b/src/ProcessSlave.php
@@ -9,7 +9,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\EventLoop\LoopInterface;
-use React\Http\Response;
+use React\Http\Message\Response;
 use React\Http\Server as HttpServer;
 use React\Promise\Promise;
 use React\Socket\ConnectionInterface;
@@ -318,7 +318,7 @@ class ProcessSlave
                 $socketPath = $this->getSlaveSocketPath($port, true);
                 $this->server = new UnixServer($socketPath, $this->loop);
 
-                $httpServer = new HttpServer([$this, 'onRequest']);
+                $httpServer = new HttpServer($this->loop, [$this, 'onRequest']);
                 $httpServer->listen($this->server);
 
                 $this->sendMessage($this->controller, 'register', ['pid' => getmypid(), 'port' => $port]);


### PR DESCRIPTION
This minimal changeset updates react/http to the stable `v1.0.0` released a few days ago: https://github.com/reactphp/http/releases/tag/v1.0.0

The tests are broken as of #503 which applied an incomplete update of this component. I've updated the code to resolve some minor BC breaks, but this doesn't seem to be covered by the existing unit tests afaict. It looks like this should be covered by some of the integration tests that are defined in the Travis CI configuration, I'm fairly confident this should verify this piece of code.

Let me know if there's anything else that needs to be done to get this merged :+1: 