### PR TITLE
Support for configuring max. concurrent requests and request body buffer

### DIFF
--- a/src/Commands/ConfigTrait.php
+++ b/src/Commands/ConfigTrait.php
@@ -28,7 +28,7 @@ trait ConfigTrait
             ->addOption('max-execution-time', null, InputOption::VALUE_REQUIRED, 'Maximum amount of time a request is allowed to execute before shutting down', 30)
             ->addOption('memory-limit', null, InputOption::VALUE_REQUIRED, 'Maximum amount of memory a worker is allowed to consume (in MB) before shutting down', -1)
             ->addOption('limit-concurrent-requests', null, InputOption::VALUE_REQUIRED, 'Max concurrent requests for the internal ReactPHP server component. Use the default ReactPHP logic when not explicitly set', null)
-            ->addOption('request-body-buffer', null, InputOption::VALUE_REQUIRED, 'Size of the request buffer (in bytes) for the internal ReactPHP server component. Default: 64000', null)
+            ->addOption('request-body-buffer', null, InputOption::VALUE_REQUIRED, 'Size of the request buffer (in bytes) for the internal ReactPHP server component. Default: 65536', null)
             ->addOption('ttl', null, InputOption::VALUE_REQUIRED, 'Time to live for a worker until it will be restarted', null)
             ->addOption('populate-server-var', null, InputOption::VALUE_REQUIRED, 'If a worker application uses $_SERVER var it needs to be populated by request data 1|0', 1)
             ->addOption('bootstrap', null, InputOption::VALUE_REQUIRED, 'Class responsible for bootstrapping the application', 'PHPPM\Bootstraps\Symfony')

--- a/src/Commands/ConfigTrait.php
+++ b/src/Commands/ConfigTrait.php
@@ -27,6 +27,8 @@ trait ConfigTrait
             ->addOption('max-requests', null, InputOption::VALUE_REQUIRED, 'Max requests per worker until it will be restarted', 1000)
             ->addOption('max-execution-time', null, InputOption::VALUE_REQUIRED, 'Maximum amount of time a request is allowed to execute before shutting down', 30)
             ->addOption('memory-limit', null, InputOption::VALUE_REQUIRED, 'Maximum amount of memory a worker is allowed to consume (in MB) before shutting down', -1)
+            ->addOption('limit-concurrent-requests', null, InputOption::VALUE_REQUIRED, 'Max concurrent requests for the internal ReactPHP server component. Use the default ReactPHP logic when not explicitly set', null)
+            ->addOption('request-body-buffer', null, InputOption::VALUE_REQUIRED, 'Size of the request buffer (in bytes) for the internal ReactPHP server component. Default: 64000', null)
             ->addOption('ttl', null, InputOption::VALUE_REQUIRED, 'Time to live for a worker until it will be restarted', null)
             ->addOption('populate-server-var', null, InputOption::VALUE_REQUIRED, 'If a worker application uses $_SERVER var it needs to be populated by request data 1|0', 1)
             ->addOption('bootstrap', null, InputOption::VALUE_REQUIRED, 'Class responsible for bootstrapping the application', 'PHPPM\Bootstraps\Symfony')
@@ -100,6 +102,8 @@ trait ConfigTrait
         $config['max-requests'] = (int)$this->optionOrConfigValue($input, 'max-requests', $config);
         $config['max-execution-time'] = (int)$this->optionOrConfigValue($input, 'max-execution-time', $config);
         $config['memory-limit'] = (int)$this->optionOrConfigValue($input, 'memory-limit', $config);
+        $config['limit-concurrent-requests'] = $this->optionOrConfigValue($input, 'limit-concurrent-requests', $config);
+        $config['request-body-buffer'] = $this->optionOrConfigValue($input, 'request-body-buffer', $config);
         $config['ttl'] = (int)$this->optionOrConfigValue($input, 'ttl', $config);
         $config['populate-server-var'] = (boolean)$this->optionOrConfigValue($input, 'populate-server-var', $config);
         $config['socket-path'] = $this->optionOrConfigValue($input, 'socket-path', $config);

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -78,6 +78,20 @@ class ProcessManager
     protected $memoryLimit = -1;
 
     /**
+     * Maximum number of next handlers allowed to be executed concurrently in ReactPHP server
+     *
+     * @var int|null
+     */
+    protected $limitConcurrentRequests = null;
+
+    /**
+     * Request body buffer size
+     *
+     * @var int|null
+     */
+    protected $requestBodyBuffer = null;
+
+    /**
      * Worker time to live
      *
      * @var int|null
@@ -352,6 +366,22 @@ class ProcessManager
     public function setMemoryLimit($memoryLimit)
     {
         $this->memoryLimit = $memoryLimit;
+    }
+
+    /**
+     * @param int $limitConcurrentRequests
+     */
+    public function setLimitConcurrentRequests($limitConcurrentRequests)
+    {
+        $this->limitConcurrentRequests = $limitConcurrentRequests;
+    }
+
+    /**
+     * @param int $requestBodyBuffer
+     */
+    public function setRequestBodyBuffer($requestBodyBuffer)
+    {
+        $this->requestBodyBuffer = $requestBodyBuffer;
     }
 
     /**
@@ -1182,7 +1212,10 @@ class ProcessManager
             'debug' => $this->isDebug(),
             'logging' => $this->isLogging(),
             'static-directory' => $this->getStaticDirectory(),
-            'populate-server-var' => $this->isPopulateServer()
+            'populate-server-var' => $this->isPopulateServer(),
+
+            'limit-concurrent-requests' => $this->limitConcurrentRequests,
+            'request-body-buffer' => $this->requestBodyBuffer
         ];
 
         $config = var_export($config, true);

--- a/src/ProcessSlave.php
+++ b/src/ProcessSlave.php
@@ -11,6 +11,10 @@ use React\EventLoop\Factory;
 use React\EventLoop\LoopInterface;
 use React\Http\Message\Response;
 use React\Http\Server as HttpServer;
+use React\Http\Middleware\StreamingRequestMiddleware;
+use React\Http\Middleware\LimitConcurrentRequestsMiddleware;
+use React\Http\Middleware\RequestBodyBufferMiddleware;
+use React\Http\Middleware\RequestBodyParserMiddleware;
 use React\Promise\Promise;
 use React\Socket\ConnectionInterface;
 use React\Socket\ServerInterface;
@@ -318,7 +322,19 @@ class ProcessSlave
                 $socketPath = $this->getSlaveSocketPath($port, true);
                 $this->server = new UnixServer($socketPath, $this->loop);
 
-                $httpServer = new HttpServer($this->loop, [$this, 'onRequest']);
+                if ($this->config['limit-concurrent-requests'] != null || $this->config['request-body-buffer'] != null) {
+                    $httpServer = new HttpServer(
+                        $this->loop,
+                        new StreamingRequestMiddleware(),
+                        new LimitConcurrentRequestsMiddleware($this->config['limit-concurrent-requests']),
+                        new RequestBodyBufferMiddleware($this->config['request-body-buffer']),
+                        new RequestBodyParserMiddleware(),
+                        [$this, 'onRequest']
+                    );
+                } else {
+                    $httpServer = new HttpServer($this->loop, [$this, 'onRequest']);
+                }
+
                 $httpServer->listen($this->server);
 
                 $this->sendMessage($this->controller, 'register', ['pid' => getmypid(), 'port' => $port]);

--- a/src/ProcessSlave.php
+++ b/src/ProcessSlave.php
@@ -326,8 +326,8 @@ class ProcessSlave
                     $httpServer = new HttpServer(
                         $this->loop,
                         new StreamingRequestMiddleware(),
-                        new LimitConcurrentRequestsMiddleware($this->config['limit-concurrent-requests']),
-                        new RequestBodyBufferMiddleware($this->config['request-body-buffer']),
+                        new LimitConcurrentRequestsMiddleware($this->config['limit-concurrent-requests'] ?? 1024),
+                        new RequestBodyBufferMiddleware($this->config['request-body-buffer'] ?? 65536),
                         new RequestBodyParserMiddleware(),
                         [$this, 'onRequest']
                     );


### PR DESCRIPTION
This PR adds configuration options for setting the parameters of `LimitConcurrentRequestsMiddleware` and `RequestBodyBufferMiddleware` middlewares in ReactPHP server.

This allows us to handle request bodies larger than 64K after the 2.1.0 release that includes https://github.com/reactphp/http/pull/371.

This PR is currently incomplete due to how we handle default values and I cannot really decide on the options below:

1) Keep the default ReactPHP server behavior by default and manually configure these two middlewares only when *both* of the new configuration options are present.

2) Remove the default behavior (HttpServer initialization without these middlewares) and configure default values in PHP-PM. We could set them to 1024 and 64K. This is probably the most clear way of configuring them from the PHP-PM perspective, but it does stop the default ReactPHP calculation from working (the way it calculates these values is described here - https://github.com/reactphp/http#server).

3) Keep the current PR code and only add default values in HttpServer initialization when only one of the two options is present. Maybe just use 1024 and 64K again for the default values, but only apply them to the undefined configuration parameter. E.g.:

```
$httpServer = new HttpServer(
    $this->loop,
    new StreamingRequestMiddleware(),
    new LimitConcurrentRequestsMiddleware($this->config['limit-concurrent-requests'] ?? 1024),
    new RequestBodyBufferMiddleware($this->config['request-body-buffer'] ?? HttpServer::MAXIMUM_BUFFER_SIZE),
    new RequestBodyParserMiddleware(),
    [$this, 'onRequest']
);
```

Also, the naming of these configuration options and the descriptions can be changed. Any suggestions are welcome.