### PR TITLE
Move register_shutdown_function from constructor to run method

### DIFF
--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -259,8 +259,6 @@ class ProcessManager
 
         $this->slaveCount = $slaveCount;
         $this->slaves = new SlavePool(); // create early, used during shutdown
-
-        register_shutdown_function([$this, 'shutdown']);
     }
 
     /**
@@ -522,6 +520,7 @@ class ProcessManager
     public function run()
     {
         Debug::enable();
+        register_shutdown_function([$this, 'shutdown']);
 
         // make whatever is necessary to disable all stuff that could buffer output
         ini_set('zlib.output_compression', 0);


### PR DESCRIPTION
I think, the shutdown function should not be registered whenever I create an instance of the ProcessManager but only when I decide to use it. This way a developer could make an instance and conditionally decide, whether he wants to run it or do something else entirely. In that situation one should not have to deal with a shutdown function that is not necessary and also calls `exit()`.