### PR TITLE
Only enable symfony error handler in debug mode

### DIFF
--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -521,7 +521,9 @@ class ProcessManager
      */
     public function run()
     {
-        Debug::enable();
+        if ($this->isDebug()) {
+            Debug::enable();
+        }
 
         // make whatever is necessary to disable all stuff that could buffer output
         ini_set('zlib.output_compression', 0);


### PR DESCRIPTION
I don't know why the Symfony error handler is always enabled. Maybe there is a deeper meaning behind it that I don't see. But if not, I propose to only use `Debug` when debugging is requested (via config or command option).