### PR TITLE
(Refactor) Preslash Simple Functions

### DIFF
--- a/.php_cs.php
+++ b/.php_cs.php
@@ -8,7 +8,6 @@ return PhpCsFixer\Config::create()
     ->setRules([
         '@PSR2' => true,
         'array_syntax' => ['syntax' => 'short'],
-        'RemoveDebugStatements/dump' => true,
         'native_function_invocation' => ['strict' => true],
     ])
     ->registerCustomFixers([new Drew\DebugStatementsFixers\Dump()])

--- a/src/Bridges/BootstrapTrait.php
+++ b/src/Bridges/BootstrapTrait.php
@@ -32,16 +32,16 @@ trait BootstrapTrait
      */
     private function normalizeBootstrapClass($appBootstrap)
     {
-        $appBootstrap = str_replace('\\\\', '\\', $appBootstrap);
+        $appBootstrap = \str_replace('\\\\', '\\', $appBootstrap);
 
         $bootstraps = [
             $appBootstrap,
             '\\' . $appBootstrap,
-            '\\PHPPM\Bootstraps\\' . ucfirst($appBootstrap)
+            '\\PHPPM\Bootstraps\\' . \ucfirst($appBootstrap)
         ];
 
         foreach ($bootstraps as $class) {
-            if (class_exists($class)) {
+            if (\class_exists($class)) {
                 return $class;
             }
         }

--- a/src/Bridges/InvokableMiddleware.php
+++ b/src/Bridges/InvokableMiddleware.php
@@ -16,7 +16,7 @@ class InvokableMiddleware implements BridgeInterface
     {
         $this->bootstrapApplicationEnvironment($appBootstrap, $appenv, $debug);
 
-        if (!is_callable($this->middleware)) {
+        if (! \is_callable($this->middleware)) {
             throw new \Exception('Middleware must implement callable');
         }
     }

--- a/src/Commands/ConfigCommand.php
+++ b/src/Commands/ConfigCommand.php
@@ -43,12 +43,12 @@ class ConfigCommand extends Command
 
         $newContent = json_encode($config, JSON_PRETTY_PRINT);
         if (file_exists($configPath) && $newContent === file_get_contents($configPath)) {
-            $output->writeln(sprintf('No changes to %s file.', realpath($configPath)));
+            $output->writeln(\sprintf('No changes to %s file.', realpath($configPath)));
             return 0;
         }
 
-        file_put_contents($configPath, $newContent);
-        $output->writeln(sprintf('<info>%s file written.</info>', realpath($configPath)));
+        \file_put_contents($configPath, $newContent);
+        $output->writeln(\sprintf('<info>%s file written.</info>', realpath($configPath)));
 
         return 0;
     }

--- a/src/Commands/ConfigTrait.php
+++ b/src/Commands/ConfigTrait.php
@@ -43,9 +43,9 @@ trait ConfigTrait
     {
         $table = new Table($output);
 
-        $rows = array_map(function ($a, $b) {
+        $rows = \array_map(function ($a, $b) {
             return [$a, $b];
-        }, array_keys($config), $config);
+        }, \array_keys($config), $config);
         $table->addRows($rows);
 
         $table->render();
@@ -60,22 +60,22 @@ trait ConfigTrait
     protected function getConfigPath(InputInterface $input, $create = false)
     {
         $configOption = $input->getOption('config');
-        if ($configOption && !file_exists($configOption)) {
+        if ($configOption && !\file_exists($configOption)) {
             if ($create) {
-                file_put_contents($configOption, json_encode([]));
+                \file_put_contents($configOption, \json_encode([]));
             } else {
-                throw new \Exception(sprintf('Config file not found: "%s"', $configOption));
+                throw new \Exception(\sprintf('Config file not found: "%s"', $configOption));
             }
         }
         $possiblePaths = [
             $configOption,
             $this->file,
-            sprintf('%s/%s', dirname($GLOBALS['argv'][0]), $this->file)
+            \sprintf('%s/%s', \dirname($GLOBALS['argv'][0]), $this->file)
         ];
 
         foreach ($possiblePaths as $path) {
-            if (file_exists($path)) {
-                return realpath($path);
+            if (\file_exists($path)) {
+                return \realpath($path);
             }
         }
         return '';
@@ -86,8 +86,8 @@ trait ConfigTrait
         $config = [];
 
         if ($path = $this->getConfigPath($input)) {
-            $content = file_get_contents($path);
-            $config = json_decode($content, true);
+            $content = \file_get_contents($path);
+            $config = \json_decode($content, true);
         }
 
         $config['bridge'] = $this->optionOrConfigValue($input, 'bridge', $config);
@@ -119,11 +119,11 @@ trait ConfigTrait
 
             $cgiPaths = [
                 $binary . '-cgi', //php7.0 -> php7.0-cgi
-                str_replace('php', 'php-cgi', $binary), //php7.0 => php-cgi7.0
+                \str_replace('php', 'php-cgi', $binary), //php7.0 => php-cgi7.0
             ];
 
             foreach ($cgiPaths as $cgiPath) {
-                $path = trim(`which $cgiPath`);
+                $path = \trim(`which $cgiPath`);
                 if ($path) {
                     $config['cgi-path'] = $path;
                     break;
@@ -157,19 +157,19 @@ trait ConfigTrait
     protected function initializeConfig(InputInterface $input, OutputInterface $output, $render = true)
     {
         if ($workingDir = $input->getArgument('working-directory')) {
-            chdir($workingDir);
+            \chdir($workingDir);
         }
         $config = $this->loadConfig($input, $output);
 
         if ($path = $this->getConfigPath($input)) {
             $modified = '';
-            $fileConfig = json_decode(file_get_contents($path), true);
-            if (json_encode($fileConfig) !== json_encode($config)) {
+            $fileConfig = \json_decode(\file_get_contents($path), true);
+            if (\json_encode($fileConfig) !== \json_encode($config)) {
                 $modified = ', modified by command arguments';
             }
-            $output->writeln(sprintf('<info>Read configuration %s%s.</info>', $path, $modified));
+            $output->writeln(\sprintf('<info>Read configuration %s%s.</info>', $path, $modified));
         }
-        $output->writeln(sprintf('<info>%s</info>', getcwd()));
+        $output->writeln(\sprintf('<info>%s</info>', \getcwd()));
 
         if ($render) {
             $this->renderConfig($output, $config);

--- a/src/Commands/StatusCommand.php
+++ b/src/Commands/StatusCommand.php
@@ -52,7 +52,7 @@ class StatusCommand extends Command
         if (is_array($status)) {
             $p = PHP_EOL;
             foreach ($status as $key => $value) {
-                $p .= sprintf('%s%s: %s', str_repeat("\t", $indentLevel), $key, $this->parseStatus($value, $indentLevel + 1));
+                $p .= \sprintf('%s%s: %s', str_repeat("\t", $indentLevel), $key, $this->parseStatus($value, $indentLevel + 1));
             }
         } else {
             $p = $status . PHP_EOL;

--- a/src/ProcessClient.php
+++ b/src/ProcessClient.php
@@ -43,7 +43,7 @@ class ProcessClient
                     $callback($result);
                 });
 
-                $connection->write(json_encode($data) . PHP_EOL);
+                $connection->write(\json_encode($data) . PHP_EOL);
             }
         );
     }
@@ -51,7 +51,7 @@ class ProcessClient
     public function getStatus(callable $callback)
     {
         $this->request('status', [], function ($result) use ($callback) {
-            $callback(json_decode($result, true));
+            $callback(\json_decode($result, true));
         });
         $this->loop->run();
     }
@@ -59,7 +59,7 @@ class ProcessClient
     public function stopProcessManager(callable $callback)
     {
         $this->request('stop', [], function ($result) use ($callback) {
-            $callback(json_decode($result, true));
+            $callback(\json_decode($result, true));
         });
         $this->loop->run();
     }
@@ -67,7 +67,7 @@ class ProcessClient
     public function reloadProcessManager(callable $callback)
     {
         $this->request('reload', [], function ($result) use ($callback) {
-            $callback(json_decode($result, true));
+            $callback(\json_decode($result, true));
         });
         $this->loop->run();
     }

--- a/src/ProcessCommunicationTrait.php
+++ b/src/ProcessCommunicationTrait.php
@@ -26,13 +26,13 @@ trait ProcessCommunicationTrait
      */
     public function processMessage(ConnectionInterface $conn, $data)
     {
-        $array = json_decode($data, true);
+        $array = \json_decode($data, true);
 
-        $method = 'command' . ucfirst($array['cmd']);
-        if (is_callable([$this, $method])) {
+        $method = 'command' . \ucfirst($array['cmd']);
+        if (\is_callable([$this, $method])) {
             $this->$method($array, $conn);
         } else {
-            throw new \Exception(sprintf('Command %s not found. Got %s', $method, $data));
+            throw new \Exception(\sprintf('Command %s not found. Got %s', $method, $data));
         }
     }
 
@@ -48,8 +48,8 @@ trait ProcessCommunicationTrait
         $conn->on('data', function ($data) use ($conn, &$buffer) {
             $buffer .= $data;
 
-            if (substr($buffer, -strlen(PHP_EOL)) === PHP_EOL) {
-                foreach (explode(PHP_EOL, $buffer) as $message) {
+            if (\substr($buffer, -\strlen(PHP_EOL)) === PHP_EOL) {
+                foreach (\explode(PHP_EOL, $buffer) as $message) {
                     if ($message) {
                         $this->processMessage($conn, $message);
                     }
@@ -70,7 +70,7 @@ trait ProcessCommunicationTrait
     protected function sendMessage(ConnectionInterface $conn, $command, array $message = [])
     {
         $message['cmd'] = $command;
-        $conn->write(json_encode($message) . PHP_EOL);
+        $conn->write(\json_encode($message) . PHP_EOL);
     }
 
     /**
@@ -83,25 +83,25 @@ trait ProcessCommunicationTrait
     {
         //since all commands set setcwd() we can make sure we are in the current application folder
 
-        if ('/' === substr($this->socketPath, 0, 1)) {
+        if ('/' === \substr($this->socketPath, 0, 1)) {
             $run = $this->socketPath;
         } else {
-            $run = getcwd() . '/' . $this->socketPath;
+            $run = \getcwd() . '/' . $this->socketPath;
         }
 
-        if ('/' !== substr($run, -1)) {
+        if ('/' !== \substr($run, -1)) {
             $run .= '/';
         }
 
         /* https://github.com/kalessil/phpinspectionsea/blob/master/docs/probable-bugs.md#mkdir-race-condition */
-        if (!is_dir($run) && !mkdir($run, 0777, true) && !is_dir($run)) {
-            throw new \RuntimeException(sprintf('Could not create %s folder.', $run));
+        if (!\is_dir($run) && !\mkdir($run, 0777, true) && !\is_dir($run)) {
+            throw new \RuntimeException(\sprintf('Could not create %s folder.', $run));
         }
 
         $sock = $run. $affix . '.sock';
 
-        if ($overwrite && file_exists($sock)) {
-            unlink($sock);
+        if ($overwrite && \file_exists($sock)) {
+            \unlink($sock);
         }
 
         return 'unix://' . $sock;

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -263,7 +263,7 @@ class ProcessManager
         $this->output->writeln("<info>Server is shutting down.</info>");
         $this->status = self::STATE_SHUTDOWN;
 
-        $remainingSlaves = count($this->slaves->getByStatus(Slave::READY));
+        $remainingSlaves = \count($this->slaves->getByStatus(Slave::READY));
 
         if ($remainingSlaves === 0) {
             // if for some reason there are no workers, the close callback won't do anything, so just quit.
@@ -275,7 +275,7 @@ class ProcessManager
 
                 if ($this->output->isVeryVerbose()) {
                     $this->output->writeln(
-                        sprintf(
+                        \sprintf(
                             'Worker #%d terminated, %d more worker(s) to close.',
                             $slave->getPort(),
                             $remainingSlaves
@@ -508,17 +508,17 @@ class ProcessManager
     public function run()
     {
         Debug::enable();
-        register_shutdown_function([$this, 'shutdown']);
+        \register_shutdown_function([$this, 'shutdown']);
 
         // make whatever is necessary to disable all stuff that could buffer output
-        ini_set('zlib.output_compression', 0);
-        ini_set('output_buffering', 0);
-        ini_set('implicit_flush', 1);
-        ob_implicit_flush(1);
+        \ini_set('zlib.output_compression', 0);
+        \ini_set('output_buffering', 0);
+        \ini_set('implicit_flush', 1);
+        \ob_implicit_flush(1);
 
         $this->loop = Factory::create();
 
-        $this->web = new Server(sprintf('%s:%d', $this->host, $this->port), $this->loop, ['backlog' => self::TCP_BACKLOG]);
+        $this->web = new Server(\sprintf('%s:%d', $this->host, $this->port), $this->loop, ['backlog' => self::TCP_BACKLOG]);
         $this->web->on('connection', [$this, 'onRequest']);
 
         $this->controller = new UnixServer($this->getControllerSocketPath(), $this->loop);
@@ -549,22 +549,22 @@ class ProcessManager
      */
     public function handleSigchld()
     {
-        $pid = pcntl_waitpid(-1, $status, WNOHANG);
+        $pid = \pcntl_waitpid(-1, $status, WNOHANG);
     }
 
     private function writePidFile()
     {
         $pid = getmypid();
-        file_put_contents($this->pidFile, $pid);
+        \file_put_contents($this->pidFile, $pid);
     }
 
     private function removePidFile()
     {
         $pid = getmypid();
-        $actualPid = (int) file_get_contents($this->pidFile);
+        $actualPid = (int) \file_get_contents($this->pidFile);
         //Only remove the pid file if it is our own
         if ($actualPid === $pid) {
-            unlink($this->pidFile);
+            \unlink($this->pidFile);
         }
     }
 
@@ -627,7 +627,7 @@ class ProcessManager
         $port = $slave->getPort();
 
         if ($this->output->isVeryVerbose()) {
-            $this->output->writeln(sprintf('Worker #%d closed after %d handled requests', $port, $slave->getHandledRequests()));
+            $this->output->writeln(\sprintf('Worker #%d closed after %d handled requests', $port, $slave->getHandledRequests()));
         }
 
         // kill slave and remove from pool
@@ -664,7 +664,7 @@ class ProcessManager
         }
 
         // create port -> requests map
-        $requests = array_reduce(
+        $requests = \array_reduce(
             $this->slaves->getByStatus(Slave::ANY),
             function ($carry, Slave $slave) {
                 $carry[$slave->getPort()] = 0 + $slave->getHandledRequests();
@@ -687,7 +687,7 @@ class ProcessManager
                 $status = 'unknown';
         }
 
-        $conn->end(json_encode([
+        $conn->end(\json_encode([
             'status' => $status,
             'workers' => $this->slaves->getStatusSummary(),
             'handled_requests' => $this->handledRequests,
@@ -709,7 +709,7 @@ class ProcessManager
             });
         }
 
-        $conn->end(json_encode([]));
+        $conn->end(\json_encode([]));
 
         $this->shutdown();
     }
@@ -731,7 +731,7 @@ class ProcessManager
             });
         }
 
-        $conn->end(json_encode([]));
+        $conn->end(\json_encode([]));
 
         $this->reloadSlaves();
     }
@@ -751,7 +751,7 @@ class ProcessManager
             $slave = $this->slaves->getByPort($port);
             $slave->register($pid, $conn);
         } catch (\Exception $e) {
-            $this->output->writeln(sprintf(
+            $this->output->writeln(\sprintf(
                 '<error>Worker #%d wanted to register on master which was not expected.</error>',
                 $port
             ));
@@ -760,7 +760,7 @@ class ProcessManager
         }
 
         if ($this->output->isVeryVerbose()) {
-            $this->output->writeln(sprintf('Worker #%d registered. Waiting for application bootstrap ... ', $port));
+            $this->output->writeln(\sprintf('Worker #%d registered. Waiting for application bootstrap ... ', $port));
         }
 
         $this->sendMessage($conn, 'bootstrap');
@@ -789,7 +789,7 @@ class ProcessManager
         $slave->ready();
 
         if ($this->output->isVeryVerbose()) {
-            $this->output->writeln(sprintf('Worker #%d ready.', $slave->getPort()));
+            $this->output->writeln(\sprintf('Worker #%d ready.', $slave->getPort()));
         }
 
         if ($this->allSlavesReady()) {
@@ -797,7 +797,7 @@ class ProcessManager
                 $this->output->writeln("<info>Emergency survived. Workers up and running again.</info>");
             } else {
                 $this->output->writeln(
-                    sprintf(
+                    \sprintf(
                         "<info>%d workers (starting at %d) up and ready. Application is ready at http://%s:%s/</info>",
                         $this->slaveCount,
                         self::CONTROLLER_PORT+1,
@@ -835,29 +835,29 @@ class ProcessManager
         try {
             $slave = $this->slaves->getByConnection($conn);
 
-            $start = microtime(true);
+            $start = \microtime(true);
 
-            clearstatcache();
+            \clearstatcache();
 
             $newFilesCount = 0;
-            $knownFiles = array_keys($this->filesLastMTime);
-            $recentlyIncludedFiles = array_diff($data['files'], $knownFiles);
+            $knownFiles = \array_keys($this->filesLastMTime);
+            $recentlyIncludedFiles = \array_diff($data['files'], $knownFiles);
             foreach ($recentlyIncludedFiles as $filePath) {
-                if (file_exists($filePath) && !is_dir($filePath)) {
-                    $this->filesLastMTime[$filePath] = filemtime($filePath);
-                    $this->filesLastMd5[$filePath] = md5_file($filePath);
+                if (\file_exists($filePath) && !\is_dir($filePath)) {
+                    $this->filesLastMTime[$filePath] = \filemtime($filePath);
+                    $this->filesLastMd5[$filePath] = \md5_file($filePath);
                     $newFilesCount++;
                 }
             }
 
             if ($this->output->isVeryVerbose()) {
                 $this->output->writeln(
-                    sprintf(
+                    \sprintf(
                         'Received %d new files from %d. Stats collection cycle: %u files, %.3f ms',
                         $newFilesCount,
                         $slave->getPort(),
-                        count($this->filesLastMTime),
-                        (microtime(true) - $start) * 1000
+                        \count($this->filesLastMTime),
+                        (\microtime(true) - $start) * 1000
                     )
                 );
             }
@@ -879,7 +879,7 @@ class ProcessManager
             $slave->setUsedMemory($data['memory_usage']);
             if ($this->output->isVeryVerbose()) {
                 $this->output->writeln(
-                    sprintf(
+                    \sprintf(
                         'Current memory usage for worker %d: %.2f MB',
                         $slave->getPort(),
                         $data['memory_usage']
@@ -905,14 +905,14 @@ class ProcessManager
                 $this->status = self::STATE_EMERGENCY;
 
                 $this->output->writeln(
-                    sprintf(
+                    \sprintf(
                         '<error>Application bootstrap failed. We are entering emergency mode now. All offline. ' .
                         'Waiting for file changes ...</error>'
                     )
                 );
             } else {
                 $this->output->writeln(
-                    sprintf(
+                    \sprintf(
                         '<error>Application bootstrap failed. We are still in emergency mode. All offline. ' .
                         'Waiting for file changes ...</error>'
                     )
@@ -922,7 +922,7 @@ class ProcessManager
             $this->reloadSlaves(false);
         } else {
             $this->output->writeln(
-                sprintf(
+                \sprintf(
                     '<error>Application bootstrap failed. Restarting worker #%d ...</error>',
                     $port
                 )
@@ -948,14 +948,14 @@ class ProcessManager
             return false;
         }
 
-        $start = microtime(true);
+        $start = \microtime(true);
         $hasChanged = false;
 
-        clearstatcache();
+        \clearstatcache();
 
         foreach ($this->filesLastMTime as $filePath => $knownMTime) {
             //If the file is a directory, just remove it from the list of tracked files
-            if (is_dir($filePath)) {
+            if (\is_dir($filePath)) {
                 unset($this->filesLastMd5[$filePath]);
                 unset($this->filesLastMTime[$filePath]);
 
@@ -963,12 +963,12 @@ class ProcessManager
             }
 
             //If the file doesn't exist anymore, remove it from the list of tracked files and restart the workers
-            if (!file_exists($filePath)) {
+            if (! \file_exists($filePath)) {
                 unset($this->filesLastMd5[$filePath]);
                 unset($this->filesLastMTime[$filePath]);
 
                 $this->output->writeln(
-                    sprintf("<info>[%s] File %s has been removed.</info>", date('d/M/Y:H:i:s O'), $filePath)
+                    \sprintf("<info>[%s] File %s has been removed.</info>", \date('d/M/Y:H:i:s O'), $filePath)
                 );
                 $hasChanged = true;
 
@@ -976,20 +976,20 @@ class ProcessManager
             }
 
             //If the file modification time has changed, update the metadata and check its contents.
-            if ($knownMTime !== $actualFileTime = filemtime($filePath)) {
+            if ($knownMTime !== $actualFileTime = \filemtime($filePath)) {
                 //update time metadata
                 $this->filesLastMTime[$filePath] = $actualFileTime;
                 if ($this->output->isVeryVerbose()) {
                     $this->output->writeln(
-                        sprintf("File %s mtime has changed, now checking its contents", $filePath)
+                        \sprintf("File %s mtime has changed, now checking its contents", $filePath)
                     );
                 }                //Only if the time AND contents have changed restart, touch() seems to change the file mtime
-                if ($this->filesLastMd5[$filePath] !== $actualFileHash = md5_file($filePath)) {
+                if ($this->filesLastMd5[$filePath] !== $actualFileHash = \md5_file($filePath)) {
                     //update file hash metadata
                     $this->filesLastMd5[$filePath] = $actualFileHash;
 
                     $this->output->writeln(
-                        sprintf("<info>[%s] File %s has changed.</info>", date('d/M/Y:H:i:s O'), $filePath)
+                        \sprintf("<info>[%s] File %s has changed.</info>", \date('d/M/Y:H:i:s O'), $filePath)
                     );
                     $hasChanged = true;
 
@@ -1000,10 +1000,10 @@ class ProcessManager
 
         if ($hasChanged) {
             $this->output->writeln(
-                sprintf(
+                \sprintf(
                     "<info>[%s] At least one of %u known files was changed. Reloading workers.</info>",
-                    date('d/M/Y:H:i:s O'),
-                    count($this->filesLastMTime)
+                    \date('d/M/Y:H:i:s O'),
+                    \count($this->filesLastMTime)
                 )
             );
 
@@ -1011,10 +1011,10 @@ class ProcessManager
         }
 
         if ($this->output->isVeryVerbose()) {
-            $this->output->writeln(sprintf(
+            $this->output->writeln(\sprintf(
                 "Changes detection cycle length = %.3f ms, %u files",
-                (microtime(true) - $start) * 1000,
-                count($this->filesLastMTime)
+                (\microtime(true) - $start) * 1000,
+                \count($this->filesLastMTime)
             ));
         }
 
@@ -1065,7 +1065,7 @@ class ProcessManager
 
             if ($this->output->isVeryVerbose()) {
                 $this->output->writeln(
-                    sprintf(
+                    \sprintf(
                         'Worker #%d has been closed, reloading.',
                         $slave->getPort()
                     )
@@ -1122,7 +1122,7 @@ class ProcessManager
 
             if ($graceful && $slave->getStatus() === Slave::BUSY) {
                 if ($this->output->isVeryVerbose()) {
-                    $this->output->writeln(sprintf('Waiting for worker #%d to finish', $slave->getPort()));
+                    $this->output->writeln(\sprintf('Waiting for worker #%d to finish', $slave->getPort()));
                 }
 
                 $slave->lock();
@@ -1130,7 +1130,7 @@ class ProcessManager
             } elseif ($graceful && $slave->getStatus() === Slave::LOCKED) {
                 if ($this->output->isVeryVerbose()) {
                     $this->output->writeln(
-                        sprintf(
+                        \sprintf(
                             'Still waiting for worker #%d to finish from an earlier reload',
                             $slave->getPort()
                         )
@@ -1154,7 +1154,7 @@ class ProcessManager
 
             foreach ($this->slavesToReload as $slave) {
                 $this->output->writeln(
-                    sprintf(
+                    \sprintf(
                         '<error>Worker #%d exceeded the graceful reload timeout and was killed.</error>',
                         $slave->getPort()
                     )
@@ -1189,7 +1189,7 @@ class ProcessManager
         if ($this->status === self::STATE_STARTING || $this->status === self::STATE_EMERGENCY) {
             $readySlaves = $this->slaves->getByStatus(Slave::READY);
             $busySlaves = $this->slaves->getByStatus(Slave::BUSY);
-            return count($readySlaves) + count($busySlaves) === $this->slaveCount;
+            return \count($readySlaves) + count($busySlaves) === $this->slaveCount;
         }
 
         return false;
@@ -1209,16 +1209,16 @@ class ProcessManager
         }
 
         if ($this->output->isVeryVerbose()) {
-            $this->output->writeln(sprintf("Start new worker #%d", $port));
+            $this->output->writeln(\sprintf("Start new worker #%d", $port));
         }
 
-        $socketpath = var_export($this->getSocketPath(), true);
-        $bridge = var_export($this->getBridge(), true);
-        $bootstrap = var_export($this->getAppBootstrap(), true);
+        $socketpath = \var_export($this->getSocketPath(), true);
+        $bridge = \var_export($this->getBridge(), true);
+        $bootstrap = \var_export($this->getAppBootstrap(), true);
 
         $config = [
             'port' => $port,
-            'session_path' => session_save_path(),
+            'session_path' => \session_save_path(),
 
             'app-env' => $this->getAppEnv(),
             'debug' => $this->isDebug(),
@@ -1230,9 +1230,9 @@ class ProcessManager
             'request-body-buffer' => $this->requestBodyBuffer
         ];
 
-        $config = var_export($config, true);
+        $config = \var_export($config, true);
 
-        $dir = var_export(__DIR__ . '/..', true);
+        $dir = \var_export(__DIR__ . '/..', true);
         $script = <<<EOF
 <?php
 
@@ -1246,7 +1246,7 @@ require_once file_exists($dir . '/vendor/autoload.php')
 
 if (!pcntl_installed()) {
     error_log(
-        sprintf(
+        \sprintf(
             'PCNTL is not enabled in the PHP installation at %s. See: http://php.net/manual/en/pcntl.installation.php',
             PHP_BINARY
         )
@@ -1265,15 +1265,15 @@ ProcessSlave::\$slave->run();
 EOF;
 
         // slave php file
-        $file = tempnam(sys_get_temp_dir(), 'dbg');
-        file_put_contents($file, $script);
-        register_shutdown_function('unlink', $file);
+        $file = \tempnam(\sys_get_temp_dir(), 'dbg');
+        \file_put_contents($file, $script);
+        \register_shutdown_function('unlink', $file);
 
         // we can not use -q since this disables basically all header support
         // but since this is necessary at least in Symfony we can not use it.
         // e.g. headers_sent() returns always true, although wrong.
         // For version 2.x and 3.x of \Symfony\Component\Process\Process package
-        if (method_exists('\Symfony\Component\Process\ProcessUtils', 'escapeArgument')) {
+        if (\method_exists('\Symfony\Component\Process\ProcessUtils', 'escapeArgument')) {
             $commandline = 'exec ' . $this->phpCgiExecutable . ' -C ' . ProcessUtils::escapeArgument($file);
         } else {
             //For version 4.x of \Symfony\Component\Process\Process package
@@ -1294,10 +1294,10 @@ EOF;
             'data',
             function ($data) use ($port) {
                 if ($this->lastWorkerErrorPrintBy !== $port) {
-                    $this->output->writeln(sprintf('<info>--- Worker %u stderr ---</info>', $port));
+                    $this->output->writeln(\sprintf('<info>--- Worker %u stderr ---</info>', $port));
                     $this->lastWorkerErrorPrintBy = $port;
                 }
-                $this->output->writeln(sprintf('<error>%s</error>', trim($data)));
+                $this->output->writeln(\sprintf('<error>%s</error>', trim($data)));
             }
         );
     }
@@ -1322,8 +1322,8 @@ EOF;
         }
 
         $pid = $slave->getPid();
-        if (is_int($pid)) {
-            posix_kill($pid, SIGKILL); // make sure it's really dead
+        if (\is_int($pid)) {
+            \posix_kill($pid, SIGKILL); // make sure it's really dead
         }
     }
 }

--- a/src/ProcessSlave.php
+++ b/src/ProcessSlave.php
@@ -338,7 +338,7 @@ class ProcessSlave
                 $httpServer->listen($this->server);
                 if ($this->isLogging()) {
                     $httpServer->on('error', function (\Exception $e) {
-                        error_log(\sprintf('Worker error while processing the request. %s: %s', get_class($e), $e->getMessage()));
+                        \error_log(\sprintf('Worker error while processing the request. %s: %s', get_class($e), $e->getMessage()));
                     });
                 }
 
@@ -410,7 +410,7 @@ class ProcessSlave
         $logTime = date('d/M/Y:H:i:s O');
 
         $catchLog = function ($e) {
-            \console_log((string) $e);
+            console_log((string) $e);
             return new Response(500);
         };
 

--- a/src/ProcessSlave.php
+++ b/src/ProcessSlave.php
@@ -161,7 +161,7 @@ class ProcessSlave
         }
 
         if ($this->errorLogger && $logs = $this->errorLogger->cleanLogs()) {
-            $messages = array_map(
+            $messages = \array_map(
                 function ($item) {
                     //array($level, $message, $context);
                     $message = $item[1];
@@ -173,7 +173,7 @@ class ProcessSlave
 
                     if (isset($context['stack'])) {
                         foreach ($context['stack'] as $idx => $stack) {
-                            $message .= PHP_EOL . sprintf(
+                            $message .= PHP_EOL . \sprintf(
                                 "#%d: %s%s %s%s",
                                 $idx,
                                 isset($stack['class']) ? $stack['class'] . '->' : '',
@@ -187,7 +187,7 @@ class ProcessSlave
                 },
                 $logs
             );
-            error_log(implode(PHP_EOL, $messages));
+            \error_log(\implode(PHP_EOL, $messages));
         }
 
         $this->inShutdown = true;
@@ -232,10 +232,10 @@ class ProcessSlave
     protected function getBridge()
     {
         if (null === $this->bridge && $this->bridgeName) {
-            if (true === class_exists($this->bridgeName)) {
+            if (true === \class_exists($this->bridgeName)) {
                 $bridgeClass = $this->bridgeName;
             } else {
-                $bridgeClass = sprintf('PHPPM\Bridges\\%s', ucfirst($this->bridgeName));
+                $bridgeClass = \sprintf('PHPPM\Bridges\\%s', ucfirst($this->bridgeName));
             }
 
             $this->bridge = new $bridgeClass;
@@ -284,11 +284,11 @@ class ProcessSlave
             return;
         }
 
-        $files = array_merge($this->watchedFiles, get_included_files());
-        $flipped = array_flip($files);
+        $files = \array_merge($this->watchedFiles, \get_included_files());
+        $flipped = \array_flip($files);
 
         //speedy way checking if two arrays are different.
-        if (!$this->lastSentFiles || array_diff_key($flipped, $this->lastSentFiles)) {
+        if (!$this->lastSentFiles || \array_diff_key($flipped, $this->lastSentFiles)) {
             $this->lastSentFiles = $flipped;
             $this->sendMessage($this->controller, 'files', ['files' => $files]);
         }
@@ -312,7 +312,7 @@ class ProcessSlave
 
                 $this->loop->addSignal(SIGTERM, [$this, 'shutdown']);
                 $this->loop->addSignal(SIGINT, [$this, 'shutdown']);
-                register_shutdown_function([$this, 'prepareShutdown']);
+                \register_shutdown_function([$this, 'prepareShutdown']);
 
                 $this->bindProcessMessage($this->controller);
                 $this->controller->on('close', [$this, 'shutdown']);
@@ -338,7 +338,7 @@ class ProcessSlave
                 $httpServer->listen($this->server);
                 if ($this->isLogging()) {
                     $httpServer->on('error', function (\Exception $e) {
-                        error_log(sprintf('Worker error while processing the request. %s: %s', get_class($e), $e->getMessage()));
+                        error_log(\sprintf('Worker error while processing the request. %s: %s', get_class($e), $e->getMessage()));
                     });
                 }
 
@@ -410,7 +410,7 @@ class ProcessSlave
         $logTime = date('d/M/Y:H:i:s O');
 
         $catchLog = function ($e) {
-            console_log((string) $e);
+            \console_log((string) $e);
             return new Response(500);
         };
 
@@ -453,13 +453,13 @@ class ProcessSlave
             try {
                 $response = $bridge->handle($request);
             } catch (\Throwable $t) {
-                error_log(
+                \error_log(
                     'An exception was thrown by the bridge. Forcing restart of the worker. The exception was: ' .
                     (string)$t
                 );
                 $response = new Response(500, [], 'Unexpected error');
 
-                @ob_end_clean();
+                @\ob_end_clean();
                 $this->shutdown();
             }
             $this->sendCurrentFiles();
@@ -467,11 +467,11 @@ class ProcessSlave
             $response = new Response(404, [], 'No Bridge defined');
         }
 
-        if (headers_sent()) {
+        if (\headers_sent()) {
             //when a script sent headers the cgi process needs to die because the second request
             //trying to send headers again will fail (headers already sent fatal). Its best to not even
             //try to send headers because this break the whole approach of php-pm using php-cgi.
-            error_log(
+            \error_log(
                 'Headers have been sent, but not redirected to client. Forcing restart of the worker. ' .
                 'Make sure your application does not send headers on its own.'
             );
@@ -485,13 +485,13 @@ class ProcessSlave
     {
         $_SERVER = $this->baseServer;
         $_SERVER['REQUEST_METHOD'] = $request->getMethod();
-        $_SERVER['REQUEST_TIME'] = (int)microtime(true);
-        $_SERVER['REQUEST_TIME_FLOAT'] = microtime(true);
+        $_SERVER['REQUEST_TIME'] = (int)\microtime(true);
+        $_SERVER['REQUEST_TIME_FLOAT'] = \microtime(true);
 
         $_SERVER['QUERY_STRING'] = $request->getUri()->getQuery();
 
         foreach ($request->getHeaders() as $name => $valueArr) {
-            $_SERVER['HTTP_' . strtoupper(str_replace('-', '_', $name))] = $request->getHeaderLine($name);
+            $_SERVER['HTTP_' . \strtoupper(\str_replace('-', '_', $name))] = $request->getHeaderLine($name);
         }
 
         //We receive X-PHP-PM-Remote-IP and X-PHP-PM-Remote-Port from ProcessManager.
@@ -505,9 +505,9 @@ class ProcessSlave
 
         $_SERVER['SERVER_NAME'] = isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : '';
         $_SERVER['REQUEST_URI'] = $request->getUri()->getPath() . ($_SERVER['QUERY_STRING'] ? '?' . $_SERVER['QUERY_STRING'] : '');
-        $_SERVER['DOCUMENT_ROOT'] = isset($_ENV['DOCUMENT_ROOT']) ? $_ENV['DOCUMENT_ROOT'] : getcwd();
+        $_SERVER['DOCUMENT_ROOT'] = isset($_ENV['DOCUMENT_ROOT']) ? $_ENV['DOCUMENT_ROOT'] : \getcwd();
         $_SERVER['SCRIPT_NAME'] = isset($_ENV['SCRIPT_NAME']) ? $_ENV['SCRIPT_NAME'] : 'index.php';
-        $_SERVER['SCRIPT_FILENAME'] = rtrim($_SERVER['DOCUMENT_ROOT'], '/') . '/' . $_SERVER['SCRIPT_NAME'];
+        $_SERVER['SCRIPT_FILENAME'] = \rtrim($_SERVER['DOCUMENT_ROOT'], '/') . '/' . $_SERVER['SCRIPT_NAME'];
     }
 
     /**
@@ -521,7 +521,7 @@ class ProcessSlave
         if ($path === '/') {
             $path = '/index.html';
         } else {
-            $path = str_replace("\\", '/', $path);
+            $path = \str_replace("\\", '/', $path);
         }
 
         $path = Utils::parseQueryPath($path);
@@ -533,18 +533,18 @@ class ProcessSlave
 
         $filePath = $this->getStaticDirectory() . $path;
 
-        if (substr($filePath, -4) === '.php' || !is_file($filePath)) {
+        if (\substr($filePath, -4) === '.php' || ! \is_file($filePath)) {
             return false;
         }
 
-        $mTime = filemtime($filePath);
+        $mTime = \filemtime($filePath);
 
         if ($request->hasHeader('If-Modified-Since')) {
             $ifModifiedSince = $request->getHeaderLine('If-Modified-Since');
-            if ($ifModifiedSince && strtotime($ifModifiedSince) === $mTime) {
+            if ($ifModifiedSince && \strtotime($ifModifiedSince) === $mTime) {
                 // Client's cache IS current, so we just respond '304 Not Modified'.
                 $response = new Response(304, [
-                    'Last-Modified' => gmdate('D, d M Y H:i:s', $mTime) . ' GMT'
+                    'Last-Modified' => \gmdate('D, d M Y H:i:s', $mTime) . ' GMT'
                 ]);
                 return $response;
             }
@@ -553,12 +553,12 @@ class ProcessSlave
         $expires = 3600; //1 h
         $response = new Response(200, [
             'Content-Type' => $this->mimeContentType($filePath),
-            'Content-Length' => filesize($filePath),
+            'Content-Length' => \filesize($filePath),
             'Pragma' => 'public',
             'Cache-Control' => 'max-age=' . $expires,
-            'Last-Modified' => gmdate('D, d M Y H:i:s', $mTime) . ' GMT',
-            'Expires' => gmdate('D, d M Y H:i:s', time() + $expires) . ' GMT'
-        ], new ReadableResourceStream(fopen($filePath, 'rb'), $this->loop));
+            'Last-Modified' => \gmdate('D, d M Y H:i:s', $mTime) . ' GMT',
+            'Expires' => \gmdate('D, d M Y H:i:s', \time() + $expires) . ' GMT'
+        ], new ReadableResourceStream(\fopen($filePath, 'rb'), $this->loop));
 
         return $response;
     }
@@ -580,7 +580,7 @@ class ProcessSlave
                 $statusCode = "<info>$statusCode</info>";
             }
 
-            $message = str_replace(
+            $message = \str_replace(
                 [
                     '$remote_addr',
                     '$remote_user',
@@ -614,9 +614,9 @@ class ProcessSlave
         if ($response->getBody() instanceof EventEmitterInterface) {
             /** @var EventEmitterInterface $body */
             $body = $response->getBody();
-            $size = strlen(\RingCentral\Psr7\str($response));
+            $size = \strlen(\RingCentral\Psr7\str($response));
             $body->on('data', function ($data) use (&$size) {
-                $size += strlen($data);
+                $size += \strlen($data);
             });
             //using `close` event since `end` is not fired for files
             $body->on('close', function () use (&$size, $logFunction) {
@@ -690,17 +690,17 @@ class ProcessSlave
             'ods' => 'application/vnd.oasis.opendocument.spreadsheet',
         ];
 
-        $ext = strtolower(substr($filename, strrpos($filename, '.') + 1));
+        $ext = \strtolower(\substr($filename, \strrpos($filename, '.') + 1));
         if (isset($mimeTypes[$ext])) {
             return $mimeTypes[$ext];
         }
 
-        if (function_exists('finfo_open')) {
-            $finfo = finfo_open(FILEINFO_MIME);
+        if (\function_exists('finfo_open')) {
+            $finfo = \finfo_open(FILEINFO_MIME);
 
             //we need to suppress all stuff of this call due to https://bugs.php.net/bug.php?id=71615
-            $mimetype = @finfo_file($finfo, $filename);
-            finfo_close($finfo);
+            $mimetype = @\finfo_file($finfo, $filename);
+            \finfo_close($finfo);
             if ($mimetype) {
                 return $mimetype;
             }

--- a/src/Slave.php
+++ b/src/Slave.php
@@ -96,7 +96,7 @@ class Slave
         $this->maxRequests = $maxRequests;
         $this->memoryLimit = $memoryLimit;
         $this->ttl = ((int) $ttl < 1) ? null : $ttl;
-        $this->startedAt = time();
+        $this->startedAt = \time();
 
         $this->status = self::CREATED;
     }
@@ -309,7 +309,7 @@ class Slave
      */
     public function isExpired()
     {
-        return null !== $this->ttl && time() >= ($this->startedAt + $this->ttl);
+        return null !== $this->ttl && \time() >= ($this->startedAt + $this->ttl);
     }
 
     /**
@@ -339,7 +339,7 @@ class Slave
                 $status = 'INVALID';
         }
 
-        return (string)print_r([
+        return (string)\print_r([
             'status' => $status,
             'port' => $this->port,
             'pid' => $this->pid

--- a/src/SlavePool.php
+++ b/src/SlavePool.php
@@ -79,7 +79,7 @@ class SlavePool
      */
     public function getByConnection(ConnectionInterface $connection)
     {
-        $hash = spl_object_hash($connection);
+        $hash = \spl_object_hash($connection);
 
         foreach ($this->slaves as $slave) {
             if ($slave->getConnection() && $hash === spl_object_hash($slave->getConnection())) {
@@ -95,7 +95,7 @@ class SlavePool
      */
     public function getByStatus($status)
     {
-        return array_filter($this->slaves, function ($slave) use ($status) {
+        return \array_filter($this->slaves, function ($slave) use ($status) {
             return $status === Slave::ANY || $status === $slave->getStatus();
         });
     }
@@ -116,8 +116,8 @@ class SlavePool
             'closed' => Slave::CLOSED
         ];
 
-        return array_map(function ($state) {
-            return count($this->getByStatus($state));
+        return \array_map(function ($state) {
+            return \count($this->getByStatus($state));
         }, $map);
     }
 }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -18,9 +18,9 @@ class Utils
      */
     public static function bindAndCall(callable $fn, $newThis, $args = [], $bindClass = null)
     {
-        $func = \Closure::bind($fn, $newThis, $bindClass ?: get_class($newThis));
+        $func = \Closure::bind($fn, $newThis, $bindClass ?: \get_class($newThis));
         if ($args) {
-            call_user_func_array($func, $args);
+            \call_user_func_array($func, $args);
         } else {
             $func(); //faster
         }
@@ -55,7 +55,7 @@ class Utils
      */
     public static function getMaxMemory()
     {
-        $memoryLimit = ini_get('memory_limit');
+        $memoryLimit = \ini_get('memory_limit');
 
         // if no limit
         if (-1 == $memoryLimit) {
@@ -63,16 +63,16 @@ class Utils
         }
 
         // if set to exact byte
-        if (is_numeric($memoryLimit)) {
+        if (\is_numeric($memoryLimit)) {
             return (int) $memoryLimit;
         }
 
         // if short hand version http://php.net/manual/en/faq.using.php#faq.using.shorthandbytes
-        return (int) substr($memoryLimit, 0, -1) * [
+        return (int) \substr($memoryLimit, 0, -1) * [
             'g' => 1073741824, // 1024 * 1024 * 1024
             'm' => 1048576, // 1024 * 1024
             'k' => 1024
-        ][strtolower(substr($memoryLimit, -1))];
+        ][\strtolower(\substr($memoryLimit, -1))];
     }
 
     /**
@@ -82,8 +82,8 @@ class Utils
      */
     public static function parseQueryPath($path)
     {
-        $path = '/' . ltrim($path, '/');
-        $path = preg_replace('/[\x00-\x1F\x7F]/', '', $path);
+        $path = '/' . \ltrim($path, '/');
+        $path = \preg_replace('/[\x00-\x1F\x7F]/', '', $path);
 
         //examples:
         //1.> /images/../foo.png
@@ -92,15 +92,15 @@ class Utils
         //1.> /images/../../foo.png
         //2.> /foo.png
         //3.> false
-        while (false !== $pos = strpos($path, '/../')) {
-            $leftSlashNext = strrpos(substr($path, 0, $pos), '/');
+        while (false !== $pos = \strpos($path, '/../')) {
+            $leftSlashNext = \strrpos(\substr($path, 0, $pos), '/');
 
             if (false === $leftSlashNext) {
                 // one /../ too much, without space to the left/up
                 return false;
             }
 
-            $path = substr($path, 0, $leftSlashNext + 1) . substr($path, $pos + 4);
+            $path = \substr($path, 0, $leftSlashNext + 1) . \substr($path, $pos + 4);
         }
 
         return $path;

--- a/src/functions.php
+++ b/src/functions.php
@@ -24,9 +24,9 @@ function register_file($path)
  */
 function console_log($expression, $_ = null)
 {
-    ob_start();
-    var_dump(...func_get_args());
-    file_put_contents('php://stderr', ob_get_clean() . PHP_EOL, FILE_APPEND);
+    \ob_start();
+    \var_dump(...\func_get_args());
+    \file_put_contents('php://stderr', \ob_get_clean() . PHP_EOL, FILE_APPEND);
 }
 
 /**
@@ -36,7 +36,7 @@ function console_log($expression, $_ = null)
  */
 function pcntl_installed()
 {
-    return function_exists('pcntl_signal');
+    return \function_exists('pcntl_signal');
 }
 
 /**
@@ -47,13 +47,13 @@ function pcntl_installed()
 function pcntl_enabled()
 {
     $requiredFunctions = ['pcntl_signal', 'pcntl_signal_dispatch', 'pcntl_waitpid'];
-    $disabledFunctions = explode(',', (string) ini_get('disable_functions'));
-    $disabledFunctions = array_map(function ($item) {
-        return trim($item);
+    $disabledFunctions = \explode(',', (string) \ini_get('disable_functions'));
+    $disabledFunctions = \array_map(function ($item) {
+        return \trim($item);
     }, $disabledFunctions);
 
     foreach ($requiredFunctions as $function) {
-        if (in_array($function, $disabledFunctions)) {
+        if (\in_array($function, $disabledFunctions)) {
             return false;
         }
     }

--- a/src/functions.php
+++ b/src/functions.php
@@ -24,9 +24,9 @@ function register_file($path)
  */
 function console_log($expression, $_ = null)
 {
-    \ob_start();
-    \var_dump(...\func_get_args());
-    \file_put_contents('php://stderr', \ob_get_clean() . PHP_EOL, FILE_APPEND);
+    ob_start();
+    var_dump(...func_get_args());
+    file_put_contents('php://stderr', ob_get_clean() . PHP_EOL, FILE_APPEND);
 }
 
 /**


### PR DESCRIPTION
- closes #423 

### `Preslash Simple Functions`

Add pre-slash to short named functions to improve performance

```diff
 class SomeClass
 {
     public function shorten($value)
     {
-        return trim($value);
+        return \trim($value);
     }
 }
```