### PR TITLE
Improve change detection to avoid multiple restarts

### DIFF
--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -949,7 +949,7 @@ class ProcessManager
         }
 
         $start = \microtime(true);
-        $hasChanged = false;
+        $numChanged = 0;
 
         \clearstatcache();
 
@@ -963,20 +963,16 @@ class ProcessManager
             }
 
             //If the file doesn't exist anymore, remove it from the list of tracked files and restart the workers
-            if (! \file_exists($filePath)) {
+            if (!\file_exists($filePath)) {
                 unset($this->filesLastMd5[$filePath]);
                 unset($this->filesLastMTime[$filePath]);
 
                 $this->output->writeln(
                     \sprintf("<info>[%s] File %s has been removed.</info>", \date('d/M/Y:H:i:s O'), $filePath)
                 );
-                $hasChanged = true;
-
-                break;
-            }
-
+                $numChanged++;
             //If the file modification time has changed, update the metadata and check its contents.
-            if ($knownMTime !== $actualFileTime = \filemtime($filePath)) {
+            } elseif ($knownMTime !== ($actualFileTime = \filemtime($filePath))) {
                 //update time metadata
                 $this->filesLastMTime[$filePath] = $actualFileTime;
                 if ($this->output->isVeryVerbose()) {
@@ -991,18 +987,17 @@ class ProcessManager
                     $this->output->writeln(
                         \sprintf("<info>[%s] File %s has changed.</info>", \date('d/M/Y:H:i:s O'), $filePath)
                     );
-                    $hasChanged = true;
-
-                    break;
+                    $numChanged++;
                 }
             }
         }
 
-        if ($hasChanged) {
+        if ($numChanged > 0) {
             $this->output->writeln(
                 \sprintf(
-                    "<info>[%s] At least one of %u known files was changed. Reloading workers.</info>",
+                    "<info>[%s] %u of %u known files was changed or removed. Reloading workers.</info>",
                     \date('d/M/Y:H:i:s O'),
+                    $numChanged,
                     \count($this->filesLastMTime)
                 )
             );
@@ -1018,7 +1013,7 @@ class ProcessManager
             ));
         }
 
-        return $hasChanged;
+        return $numChanged > 0;
     }
 
     /**


### PR DESCRIPTION
Right now, when the first change in a file is detected, the slaves are immediately restarted. That causes multiple restarts if another file in the tracked ones was also changed or removed.

With this change, we now scan all the tracked files and just keep track of how many files have changed and then proceed to restart the slaves.

In theory, the previous method was more optimal because it avoided scanning the remaining of the files if a change was detected early. But this assumed that only 1 file changed per cycle. This is what normally happens when manually coding, it's rare to edit 2 files in 1 second. But in the case of Symfony (or other framework) cache files, it's pretty normal to have a lot of changes and every one of those changes would trigger a restart of the slaves. With this change, only 1 restart will be performed for all the files changed within the 1s detection cycle.