### PR TITLE
Add Symfony 6 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@
 /vendor/
 /.vscode/
 /.ppm/
+/web/
 composer.lock
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -5,9 +5,9 @@
     "require": {
         "php": "^7.3 || ^8.0 ",
         "ext-pcntl": "*",
-        "symfony/console": "^3.4|^4|^5",
-        "symfony/error-handler": "^4.4|^5",
-        "symfony/process": "^3.4|^4|^5",
+        "symfony/console": "^4|^5|^6",
+        "symfony/error-handler": "^4.4|^5|^6",
+        "symfony/process": "^4|^5|^6",
         "react/event-loop": "^1.0",
         "react/http": ">=1.0 <1.3",
         "react/stream": "^1.0",


### PR DESCRIPTION
Remove SF 3.4 as it is EOL'd as of November 2021 and no longer receives updates (https://symfony.com/releases/3.4)