### PR TITLE
Block keep-alive in HTTP 1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "symfony/error-handler": "^4.4|^5",
         "symfony/process": "^3.4|^4|^5",
         "react/event-loop": "^1.0",
-        "react/http": ">=1.0 <1.3",
+        "react/http": "^1.0",
         "react/stream": "^1.0",
         "react/socket": "^1.0",
         "react/child-process": "^0.6",

--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -122,7 +122,8 @@ class RequestHandler
             $remoteAddress = (string) $this->incoming->getRemoteAddress();
             $headersToReplace = [
                 'X-PHP-PM-Remote-IP' => \trim(\parse_url($remoteAddress, PHP_URL_HOST), '[]'),
-                'X-PHP-PM-Remote-Port' => \trim(\parse_url($remoteAddress, PHP_URL_PORT), '[]')
+                'X-PHP-PM-Remote-Port' => \trim(\parse_url($remoteAddress, PHP_URL_PORT), '[]'),
+                'Connection' => 'close'
             ];
 
             $buffer = $this->replaceHeader($this->incomingBuffer, $headersToReplace);


### PR DESCRIPTION
Keep-alives are disabled by injecting "Connection: close" in the HTTP request.

Allows upgrading to ReactPHP/HTTP v1.3, so the version limitation is lifted.

Fixes #538 

