### PR TITLE
Don't mention the term "slave" in public error messages

### DIFF
--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -160,7 +160,7 @@ class RequestHandler
             $this->loop->futureTick([$this, 'getNextSlave']);
         } else {
             // Return a "503 Service Unavailable" response
-            $this->output->writeln(\sprintf('No slaves available to handle the request and timeout %d seconds exceeded', $this->timeout));
+            $this->output->writeln(\sprintf('No worker processes available to handle the request and timeout %d seconds exceeded', $this->timeout));
             $this->incoming->write($this->createErrorResponse('503 Service Temporarily Unavailable', 'Service Temporarily Unavailable'));
             $this->incoming->end();
         }


### PR DESCRIPTION
Let's not give the impression that slaves are used in websites using php-pm. It may be justified as being technical jargon (though avoided in many projects by now), but this is an error shown in browsers to regular users.