### PR TITLE
Add support for setting $_SERVER['HTTPS'] var

### DIFF
--- a/src/ProcessSlave.php
+++ b/src/ProcessSlave.php
@@ -503,11 +503,17 @@ class ProcessSlave
         unset($_SERVER['HTTP_REMOTE_PORT']);
         unset($_SERVER['HTTP_X_PHP_PM_REMOTE_PORT']);
 
+
         $_SERVER['SERVER_NAME'] = isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : '';
         $_SERVER['REQUEST_URI'] = $request->getUri()->getPath() . ($_SERVER['QUERY_STRING'] ? '?' . $_SERVER['QUERY_STRING'] : '');
         $_SERVER['DOCUMENT_ROOT'] = isset($_ENV['DOCUMENT_ROOT']) ? $_ENV['DOCUMENT_ROOT'] : \getcwd();
         $_SERVER['SCRIPT_NAME'] = isset($_ENV['SCRIPT_NAME']) ? $_ENV['SCRIPT_NAME'] : 'index.php';
         $_SERVER['SCRIPT_FILENAME'] = \rtrim($_SERVER['DOCUMENT_ROOT'], '/') . '/' . $_SERVER['SCRIPT_NAME'];
+
+        // For correct SSL detection is often the $_SERVER['HTTPS'] var used - so check if X-Forwarded-Proto is set and when it has https set that var to 'on'
+        $_SERVER['HTTPS'] = (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO']=="https") 
+            ? 'on' 
+            : 'off';
     }
 
     /**


### PR DESCRIPTION
I replaced my php-fpm with that project for Laravel and use a NGINX proxy in front of it.
With PHP FPM i had a scheme detection which was set the HTTPS var on FastCGI for forcing Laravel to generate https urls.
After I run that with php-ppm i noticed that the X-Forwarded-Proto is not working, as i looked in the code i saw that this var is not parsed and no HTTPS var is set on $_SERVER array.

So that pull request to fix that.