### PR TITLE
Add posibility to restart workers immediately after TTL will expire

### DIFF
--- a/integration_test.sh
+++ b/integration_test.sh
@@ -46,3 +46,17 @@ bash -c 'grep -q "This is a very bad exception" /tmp/ppmout && exit 0'
 bash -c 'grep -q "Shutdown function triggered" /tmp/ppmoutshutdownfunc && exit 0'
 bin/ppm status
 bin/ppm stop
+# TTL expiration with ttl-restart-strategy set to request
+bin/ppm start --workers=1 --bridge=PHPPM\\Tests\\TestBridge --static-directory=web --max-requests=10 --max-execution-time=15 --ttl=5 -v > /tmp/ppmout &
+sleep 5
+bash -c 'if grep -q "Restart worker #5501 because it reached its TTL" /tmp/ppmout; then exit 1; else exit 0; fi'
+curl -f --silent "http://127.0.0.1:8080"
+bash -c 'grep -qv "Restart worker #5501 because it reached its TTL" /tmp/ppmout || exit 1'
+bin/ppm status
+bin/ppm stop
+#TTL expiration with ttl-restart-strategy set to expire
+bin/ppm start --workers=1 --bridge=PHPPM\\Tests\\TestBridge --static-directory=web --max-requests=10 --max-execution-time=15 --ttl=1 --ttl-restart-strategy=expire -v > /tmp/ppmout &
+sleep 6
+bash -c 'grep -qv "Restart worker #5501 because it reached its TTL" /tmp/ppmout || exit 1'
+bin/ppm status
+bin/ppm stop

--- a/src/Commands/ConfigTrait.php
+++ b/src/Commands/ConfigTrait.php
@@ -30,6 +30,7 @@ trait ConfigTrait
             ->addOption('limit-concurrent-requests', null, InputOption::VALUE_REQUIRED, 'Max concurrent requests for the internal ReactPHP server component. Use the default ReactPHP logic when not explicitly set', null)
             ->addOption('request-body-buffer', null, InputOption::VALUE_REQUIRED, 'Size of the request buffer (in bytes) for the internal ReactPHP server component. Default: 65536', null)
             ->addOption('ttl', null, InputOption::VALUE_REQUIRED, 'Time to live for a worker until it will be restarted', null)
+            ->addOption('ttl-restart-strategy', null, InputOption::VALUE_REQUIRED, 'Strategy used for restart workers when ttl is exceeded. request|expire Default: request', 'request')
             ->addOption('populate-server-var', null, InputOption::VALUE_REQUIRED, 'If a worker application uses $_SERVER var it needs to be populated by request data 1|0', 1)
             ->addOption('bootstrap', null, InputOption::VALUE_REQUIRED, 'Class responsible for bootstrapping the application', 'PHPPM\Bootstraps\Symfony')
             ->addOption('cgi-path', null, InputOption::VALUE_REQUIRED, 'Full path to the php-cgi executable', false)
@@ -105,6 +106,7 @@ trait ConfigTrait
         $config['limit-concurrent-requests'] = $this->optionOrConfigValue($input, 'limit-concurrent-requests', $config);
         $config['request-body-buffer'] = $this->optionOrConfigValue($input, 'request-body-buffer', $config);
         $config['ttl'] = (int)$this->optionOrConfigValue($input, 'ttl', $config);
+        $config['ttl-restart-strategy'] = $this->optionOrConfigValue($input, 'ttl-restart-strategy', $config);
         $config['populate-server-var'] = (boolean)$this->optionOrConfigValue($input, 'populate-server-var', $config);
         $config['socket-path'] = $this->optionOrConfigValue($input, 'socket-path', $config);
         $config['pidfile'] = $this->optionOrConfigValue($input, 'pidfile', $config);

--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -44,6 +44,7 @@ class StartCommand extends Command
         $handler->setMaxExecutionTime($config['max-execution-time']);
         $handler->setMemoryLimit($config['memory-limit']);
         $handler->setTtl($config['ttl']);
+        $handler->setTtlRestartStrategy($config['ttl-restart-strategy']);
         $handler->setPhpCgiExecutable($config['cgi-path']);
         $handler->setSocketPath($config['socket-path']);
         $handler->setPidFile($config['pidfile']);

--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -145,11 +145,8 @@ class RequestHandler
             return;
         }
 
-        $available = $this->slaves->getByStatus(Slave::READY);
-        if (\count($available)) {
-            // pick first slave
-            $slave = \array_shift($available);
-
+        $slave = $this->slaves->findReadySlave();
+        if ($slave !== null) {
             // slave available -> connect
             if ($this->tryOccupySlave($slave)) {
                 return;
@@ -192,13 +189,6 @@ class RequestHandler
      */
     public function tryOccupySlave(Slave $slave)
     {
-        if ($slave->isExpired()) {
-            $slave->close();
-            $this->output->writeln(\sprintf('Restart worker #%d because it reached its TTL', $slave->getPort()));
-            $slave->getConnection()->close();
-            return false;
-        }
-
         $this->redirectionTries++;
 
         $this->slave = $slave;

--- a/src/Slave.php
+++ b/src/Slave.php
@@ -312,6 +312,11 @@ class Slave
         return null !== $this->ttl && \time() >= ($this->startedAt + $this->ttl);
     }
 
+    public function getTtl()
+    {
+        return $this->ttl;
+    }
+
     /**
      * String conversion for debugging
      *

--- a/tests/SlavePoolTest.php
+++ b/tests/SlavePoolTest.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace PHPPM\Tests;
+
+use PHPPM\Slave;
+use PHPPM\SlavePool;
+use React\EventLoop\LoopInterface;
+use React\EventLoop\TimerInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SlavePoolTest extends PhpPmTestCase
+{
+    /**
+     * @dataProvider validTtlRestartStrategyDataProvider
+     */
+    public function testShouldSetTtlRestartStrategy($strategy)
+    {
+        $this->expectNotToPerformAssertions();
+
+        $slavePool = new SlavePool(
+            $this->createMock(LoopInterface::class),
+            $this->createMock(OutputInterface::class)
+        );
+
+        $slavePool->setTtlRestartStrategy($strategy);
+    }
+
+    public function validTtlRestartStrategyDataProvider()
+    {
+        return [
+            'request' => ['request'],
+            'expire' => ['expire'],
+        ];
+    }
+
+    public function testShouldNotSetInvalidTtlRestartStrategy()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid ttl restart strategy. Expected request or expire but invalid_strategy given');
+
+        $slavePool = new SlavePool(
+            $this->createMock(LoopInterface::class),
+            $this->createMock(OutputInterface::class),
+        );
+
+        $slavePool->setTtlRestartStrategy('invalid_strategy');
+    }
+
+    public function testShouldNotSetRestartTimerOnDefaultStrategy()
+    {
+        $loop = $this->createMock(LoopInterface::class);
+
+        $loop->expects(self::never())->method('addTimer');
+
+        $slavePool = new SlavePool(
+            $loop,
+            $this->createMock(OutputInterface::class),
+        );
+
+        $slavePool->add($this->createMock(Slave::class));
+    }
+
+    /**
+     * @dataProvider ttlDataProvider
+     */
+    public function testShouldSetRestartTimerForExpireStrategyWithSmallTtl($ttl, $min, $max)
+    {
+        $loop = $this->createMock(LoopInterface::class);
+
+        $loop
+            ->expects(self::once())
+            ->method('addTimer')
+            ->with(self::logicalAnd(
+                self::greaterThanOrEqual($min),
+                self::lessThanOrEqual($max)
+            ));
+
+        $slavePool = new SlavePool(
+            $loop,
+            $this->createMock(OutputInterface::class),
+        );
+
+        $slavePool->setTtlRestartStrategy('expire');
+
+        $slavePool->add($this->createConfiguredMock(Slave::class, [
+            'getTtl' => $ttl
+        ]));
+    }
+
+    public function ttlDataProvider()
+    {
+        return [
+            'small ttl' => [5, 5, 10],
+            'bigger ttl' => [60, 55, 65]
+        ];
+    }
+
+    public function testShouldCancelTimerOnSlaveRemoval()
+    {
+        $loop = $this->createMock(LoopInterface::class);
+        $timer = $this->createMock(TimerInterface::class);
+
+        $loop
+            ->method('addTimer')
+            ->willReturn($timer);
+
+        $loop
+            ->expects(self::once())
+            ->method('cancelTimer')
+            ->with(self::equalTo($timer));
+
+        $slavePool = new SlavePool(
+            $loop,
+            $this->createMock(OutputInterface::class)
+        );
+        $slavePool->setTtlRestartStrategy('expire');
+
+        $slave = $this->createConfiguredMock(Slave::class, [
+            'getTtl' => 20,
+            'getPort' => 5001
+        ]);
+
+        $slavePool->add($slave);
+        $slavePool->remove($slave);
+    }
+
+    public function testShouldFindOneSlaveWithReadyState()
+    {
+        $slavePool = new SlavePool(
+            $this->createMock(LoopInterface::class),
+            $this->createMock(OutputInterface::class),
+        );
+
+        $busySlave = $this->createConfiguredMock(Slave::class, [
+            'getPort' => 5001,
+            'getStatus' => Slave::BUSY,
+        ]);
+        $readySlave = $this->createConfiguredMock(Slave::class, [
+            'getPort' => 5002,
+            'getStatus' => Slave::READY,
+        ]);
+
+        $slavePool->add($busySlave);
+        $slavePool->add($readySlave);
+
+        self::assertSame($readySlave, $slavePool->findReadySlave());
+    }
+
+    public function testShouldReturnNullWhenNoReadySlaveFound()
+    {
+        $slavePool = new SlavePool(
+            $this->createMock(LoopInterface::class),
+            $this->createMock(OutputInterface::class),
+        );
+
+        $busySlave = $this->createConfiguredMock(Slave::class, [
+            'getPort' => 5001,
+            'getStatus' => Slave::BUSY,
+        ]);
+
+        $slavePool->add($busySlave);
+
+        self::assertNull($slavePool->findReadySlave());
+    }
+}

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -3,6 +3,8 @@
 namespace PHPPM\Tests;
 
 use PHPPM\Utils;
+use React\EventLoop\LoopInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class UtilsTest extends PhpPmTestCase
 {
@@ -35,7 +37,7 @@ class UtilsTest extends PhpPmTestCase
 
     public function testHijackProperty()
     {
-        $object = new \PHPPM\SlavePool();
+        $object = new \PHPPM\SlavePool($this->createMock(LoopInterface::class), $this->createMock(OutputInterface::class));
         Utils::hijackProperty($object, 'slaves', ['SOME VALUE']);
 
         $r = new \ReflectionObject($object);


### PR DESCRIPTION
Hi,
I've noticed that when ttl is set and expired then all workers are restarted in the same time. This causes bigger lag with response from ppm. It is bigger problem when bootstrap of application is heavy.

My proposal is to add another strategy to handle workers restart when ttl will expire. Workers will be restarted immediately after ttl will expire +/-5 sec. This should keep workers fresh and should prevent workers from restarting at the same time.

To enable this behavior `ttl-restart-strategy` cli parameter or config parameter need to be set on `expire`. By default ppm will restart workers due to ttl expiration only when request will be received. As it is handled in current implementation.