### PR TITLE
Add option to toggle extra worker info

### DIFF
--- a/.php_cs.php
+++ b/.php_cs.php
@@ -10,7 +10,7 @@ return (new PhpCsFixer\Config())
     ->setRules([
         '@PSR2' => true,
         'array_syntax' => ['syntax' => 'short'],
-        'native_function_invocation' => ['strict' => true],
+        'native_function_invocation' => ['strict' => true, 'include' => ['@internal']],
     ])
     // ->registerCustomFixers([new Drew\DebugStatementsFixers\Dump()])
     ->setRiskyAllowed(true)

--- a/src/Commands/ConfigTrait.php
+++ b/src/Commands/ConfigTrait.php
@@ -36,6 +36,7 @@ trait ConfigTrait
             ->addOption('socket-path', null, InputOption::VALUE_REQUIRED, 'Path to a folder where socket files will be placed. Relative to working-directory or cwd()', '.ppm/run/')
             ->addOption('pidfile', null, InputOption::VALUE_REQUIRED, 'Path to a file where the pid of the master process is going to be stored', '.ppm/ppm.pid')
             ->addOption('reload-timeout', null, InputOption::VALUE_REQUIRED, 'The number of seconds to wait before force closing a worker during a reload, or -1 to disable. Default: 30', 30)
+            ->addOption('decorate-workers-output', null, InputOption::VALUE_REQUIRED, 'Enable/Disable displaying additional worker info in server output. 1|0', 1)
             ->addOption('config', 'c', InputOption::VALUE_REQUIRED, 'Path to config file', '');
     }
 
@@ -109,6 +110,7 @@ trait ConfigTrait
         $config['socket-path'] = $this->optionOrConfigValue($input, 'socket-path', $config);
         $config['pidfile'] = $this->optionOrConfigValue($input, 'pidfile', $config);
         $config['reload-timeout'] = $this->optionOrConfigValue($input, 'reload-timeout', $config);
+        $config['decorate-workers-output'] = $this->optionOrConfigValue($input, 'decorate-workers-output', $config);
 
         $config['cgi-path'] = $this->optionOrConfigValue($input, 'cgi-path', $config);
 

--- a/src/Commands/StartCommand.php
+++ b/src/Commands/StartCommand.php
@@ -51,6 +51,7 @@ class StartCommand extends Command
         $handler->setStaticDirectory($config['static-directory']);
         $handler->setRequestBodyBuffer($config['request-body-buffer']);
         $handler->setLimitConcurrentRequests($config['limit-concurrent-requests']);
+        $handler->setDecorateWorkersOutput($config['decorate-workers-output']);
         $handler->run();
 
         return 0;

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -218,6 +218,11 @@ class ProcessManager
     protected $pidFile;
 
     /**
+     * Whether to add additional information to logs about worker source
+     */
+    protected $decorateWorkersOutput = true;
+
+    /**
      * Controller port
      */
     const CONTROLLER_PORT = 5500;

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -1285,10 +1285,17 @@ EOF;
             'data',
             function ($data) use ($port) {
                 if ($this->lastWorkerErrorPrintBy !== $port) {
-                    $this->output->writeln(\sprintf('<info>--- Worker %u stderr ---</info>', $port));
+                    if ($this->decorateWorkersOutput) {
+                        $this->output->writeln(\sprintf('<info>--- Worker %u stderr ---</info>', $port));
+                    }
                     $this->lastWorkerErrorPrintBy = $port;
                 }
-                $this->output->writeln(\sprintf('<error>%s</error>', \trim($data)));
+                if ($this->decorateWorkersOutput) {
+                    $output = sprintf('<error>%s</error>', \trim($data));
+                } else {
+                    $output = \trim($data);
+                }
+                $this->output->writeln($output);
             }
         );
     }

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -1300,7 +1300,7 @@ EOF;
                     $this->lastWorkerErrorPrintBy = $port;
                 }
                 if ($this->decorateWorkersOutput) {
-                    $output = sprintf('<error>%s</error>', \trim($data));
+                    $output = \sprintf('<error>%s</error>', \trim($data));
                 } else {
                     $output = \trim($data);
                 }

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -473,6 +473,15 @@ class ProcessManager
     {
         $this->pidFile = $pidFile;
     }
+
+    /**
+     * @param bool $decorate
+     */
+    public function setDecorateWorkersOutput($decorate)
+    {
+        $this->decorateWorkersOutput = $decorate;
+    }
+
     /**
      * @return boolean
      */


### PR DESCRIPTION
This adds a new option to disable the `--- Worker xxxx stderr ---` lines from being written to the server output. The actual stderr output will continue to be logged.

This makes it possible to effectively use `stderr` as application logs from within workers (common in a Dockerized environment) without a lot of distraction. Usage: `vendor/bin/ppm start --decorate-workers-output=0` or add `"decorate-workers-output": 0` into `ppm.json`. I also verified that `vendor/bin/ppm config` includes the new value in the generated file.

Note: the name came from the [PHP-FPM config](https://www.php.net/manual/en/install.fpm.configuration.php#decorate-workers-output) which has similar behavior.