### PR TITLE
remove legacy backquote

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ Does your app/library support PPM? Show it!
 cd into/your-application
 
 # run Symfony
-docker run -v `pwd`:/var/www -p 8080:80 phppm/nginx --bootstrap=symfony --static-directory=web/
+docker run -v "$(pwd):/var/www" -p 8080:80 phppm/nginx --bootstrap=symfony --static-directory=web/
 
 # run Laravel
-docker run -v `pwd`:/var/www -p 8080:80 phppm/nginx --bootstrap=laravel --static-directory=public/
+docker run -v "$(pwd):/var/www" -p 8080:80 phppm/nginx --bootstrap=laravel --static-directory=public/
 ```
 
 Docker is easier to setup and maintain. If your applications requires additional environment tools or libraries,


### PR DESCRIPTION
- In bash, always prefer `` $(...) `` syntax over legacy `` `...` ``. [](_ "Double backticks here = code")
- Always quote command substitutions. If the current directory contains a space, this command with an unquoted substitution would fail.